### PR TITLE
Rpm fixes

### DIFF
--- a/rpm/harbour-amazfish.spec
+++ b/rpm/harbour-amazfish.spec
@@ -38,6 +38,7 @@ BuildRequires:  kdb-devel >= 3.1.0
 BuildRequires:  kcoreaddons-devel >= 5.31.0
 BuildRequires:  qt5-qtwidgets-devel
 BuildRequires:  qt5-qtxml-devel
+BuildRequires:  qt5-qttools-linguist
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-amazfish.spec
+++ b/rpm/harbour-amazfish.spec
@@ -77,7 +77,8 @@ desktop-file-install --delete-original       \
 
 %files
 %defattr(-,root,root,-)
-%{_bindir}
+%{_bindir}/%{name}-ui
+%{_bindir}/%{name}d
 %{_datadir}/%{name}-ui
 %{_datadir}/applications/%{name}-ui.desktop
 %{_datadir}/icons/hicolor/*/apps/%{name}-ui.png

--- a/rpm/harbour-amazfish.yaml
+++ b/rpm/harbour-amazfish.yaml
@@ -37,6 +37,7 @@ PkgBR:
   - kcoreaddons-devel >= 5.31.0
   - qt5-qtwidgets-devel
   - qt5-qtxml-devel
+  - qt5-qttools-linguist
 
 # Runtime dependencies which are not automatically detected
 Requires:

--- a/rpm/harbour-amazfish.yaml
+++ b/rpm/harbour-amazfish.yaml
@@ -49,7 +49,8 @@ Requires:
 
 # All installed files
 Files:
-  - '%{_bindir}'
+  - '%{_bindir}/%{name}-ui'
+  - '%{_bindir}/%{name}d'
   - '%{_datadir}/%{name}-ui'
   - '%{_datadir}/applications/%{name}-ui.desktop'
   - '%{_datadir}/icons/hicolor/*/apps/%{name}-ui.png'


### PR DESCRIPTION
- Fix missing lupdate and lrelease on builds outside of the SDK
- Fix standard-dir-owned-by-package /usr/bin