### PR TITLE
Fix right wrist assignment in mibandservice.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+harbour-amazfish.pro.user

--- a/daemon/src/services/mibandservice.cpp
+++ b/daemon/src/services/mibandservice.cpp
@@ -360,7 +360,7 @@ void MiBandService::setWearLocation()
         writeValue(UUID_CHARACTERISTIC_MIBAND_USER_SETTINGS, QByteArray(WEAR_LOCATION_LEFT_WRIST, 4));
         break;
     case 1:
-        writeValue(UUID_CHARACTERISTIC_MIBAND_USER_SETTINGS, QByteArray(WEAR_LOCATION_LEFT_WRIST, 4));
+        writeValue(UUID_CHARACTERISTIC_MIBAND_USER_SETTINGS, QByteArray(WEAR_LOCATION_RIGHT_WRIST, 4));
         break;
     }
 }


### PR DESCRIPTION
Whilst perusing the code to try to figure out why my Band 2's heart rate data is no longer appearing in the app, I spotted that the switch allowing the user to specify which wrist they wear their watch on specified the left wrist twice.  So I fixed it, assuming that I read the keys in the correct order.  The app builds and runs on my Xperia XA2 running SFOS 3.1.0.11.