### PR TITLE
little bug-fix for time format selection 

### DIFF
--- a/ui/qml/pages/Settings-device.qml
+++ b/ui/qml/pages/Settings-device.qml
@@ -97,8 +97,8 @@ Page {
                 label: qsTr("Time Format")
 
                 menu: ContextMenu {
-                    MenuItem { text: qsTr("12hr") }
                     MenuItem { text: qsTr("24hr") }
+                    MenuItem { text: qsTr("12hr") }
                 }
             }
 


### PR DESCRIPTION
the time format selection was swapped, now the watch follows the gui (bug was reported by erdzas on OpenRepos comments)