### PR TITLE
Rename u_int32_t to uint32_t

### DIFF
--- a/daemon/src/devices/abstractfirmwareinfo.h
+++ b/daemon/src/devices/abstractfirmwareinfo.h
@@ -35,7 +35,7 @@ public:
 protected:
     QByteArray m_bytes;
     uint16_t m_crc16;
-    u_int32_t m_crc32;
+    uint32_t m_crc32;
     Type m_type;
     QString m_version;
 


### PR DESCRIPTION
This fixes building on Musl (and thus Alpine Linux/postmarketOS)