### PR TITLE
Fix compatibility with Busybox cp

### DIFF
--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -231,7 +231,7 @@ js.path = $$DATADIR/qml/tools
 icons.files = qml/pics/*.png qml/pics/devices  qml/custom-icons
 icons.path = $$DATADIR/qml/pics
 
-qmlplatform.extra = mkdir -p ${INSTALL_ROOT}$$DATADIR/qml/components/platform && cp -L -v $$PWD/qml/components/platform.$$FLAVOR/*.qml -t ${INSTALL_ROOT}$$DATADIR/qml/components/platform
+qmlplatform.extra = mkdir -p ${INSTALL_ROOT}$$DATADIR/qml/components/platform && cp -L -v $$PWD/qml/components/platform.$$FLAVOR/*.qml ${INSTALL_ROOT}$$DATADIR/qml/components/platform
 qmlplatform.path = $$DATADIR/qml/platform
 
 INSTALLS += qmlplatform qml js icons


### PR DESCRIPTION
The "-t" argument is unnecessary and unsupported by Busybox (and I guess POSIX), just drop it