### PR TITLE
Add WIP clickable.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 harbour-amazfish.pro.user
+
+# Clickable
+/.clickable/
+/build/
+/libs/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,26 @@
+# Build
+
+## Ubuntu Touch
+
+[Clickable](https://clickable-ut.dev/en/latest/install.html) is used to build and
+debug the app for Ubuntu Touch.
+
+Download dependencies:
+
+```bash
+clickable prepare-deps
+```
+
+Build dependencies:
+
+```bash
+clickable build-libs --arch arm64 # or amd64 or armhf
+```
+
+Build the app:
+
+```bash
+clickable build --arch arm64 # or amd64 or armhf
+```
+
+For more details see [Clickable Documentation](https://clickable-ut.dev/en/latest/usage.html).

--- a/clickable.json
+++ b/clickable.json
@@ -3,5 +3,16 @@
   "builder": "qmake",
   "build_args": [
     "FLAVOR=uuitk"
-  ]
+  ],
+  "env_vars": {
+    "PKG_CONFIG_PATH": "${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/pkgconfig"
+  },
+  "scripts": {
+    "prepare-deps": "git clone https://git.sailfishos.org/mer-core/qtmpris.git libs/qtmpris"
+  },
+  "libraries": {
+    "qtmpris": {
+      "builder": "qmake"
+    }
+  }
 }

--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,7 @@
+{
+  "clickable_minimum_required": "6.20.0",
+  "builder": "qmake",
+  "build_args": [
+    "FLAVOR=uuitk"
+  ]
+}


### PR DESCRIPTION
This app seems to make use of the [Convergence Components](https://gitlab.com/dylanvanassche/convergence-components) and therefore theoretically support Ubuntu Touch (UT). I was curious to see if we can build an Ubuntu Touch click package with [Clickable](https://clickable-ut.dev/en/latest/) (even though I don't have the smart watch), so I did the first step, adding a `clickable.json`.

I ran into `Project ERROR: mpris-qt5 development package not found`. I assume the package needed in Ubuntu is `libmpris-qt5-dev`, which is in Ubuntu 20.04, but not 16.04, which Ubuntu Touch is still based on.

So I got a few questions:
- What is the minimum Qt version required? (UT has 5.9, but is shifting to 5.12 soon)
- What other dependencies are there besides `mpris-qt5`? (maybe you could add build instructions to the `README.md`?)
- Do you think it is fairly easy to build missing dependencies like `mpris-qt5` so we can ship them with the app?
- Any special system service or other integration needed?

Even if it might not be possible at the moment, this can serve as a starting point for whoever wants to pick it up later, maybe after Ubuntu Touch shifted to Ubuntu 20.04.