### PR TITLE
expose deviceEvent as deviceEventTriggered to DBus

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -425,6 +425,7 @@ void DeviceInterface::musicChanged()
 void DeviceInterface::deviceEvent(AbstractDevice::Events event)
 {
     qDebug() << Q_FUNC_INFO << event;
+    emit deviceEventTriggered(QMetaEnum::fromType<AbstractDevice::Events>().valueToKey(event));
     switch(event) {
     case AbstractDevice::EVENT_MUSIC_STOP:
         m_musicController.pause();

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -53,6 +53,7 @@ public:
     Q_SIGNAL void downloadProgress(int percent);
     Q_SIGNAL void operationRunningChanged();
     Q_SIGNAL void buttonPressed(int presses);
+    Q_SIGNAL void deviceEventTriggered(const QString& event);
     Q_SIGNAL void informationChanged(int infoKey, const QString& infoValue);
     Q_SIGNAL void connectionStateChanged();
 


### PR DESCRIPTION
Exposes events, supplies the enum name as string argument. Tested with a test build of slumber by matching "EVENT_APP_MUSIC", works well. 
Nonetheless: If this is rubbish, please let me know. ;)

cheers!

