### PR TITLE
add time_sleep ranges; dont use locale for formatting hh:mm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 harbour-amazfish.pro.user*
+
+.qmake.conf
+.qmake.stash
+Makefile
+qmake_variables.*
+lib/
+**/*.pro.user

--- a/ui/qml/pages/SleepPage.qml
+++ b/ui/qml/pages/SleepPage.qml
@@ -11,9 +11,10 @@ PagePL {
     property var day: new Date()
 
     function _formatHours(hours) {
-        var offset = new Date().getTimezoneOffset()
-        //: Format of sleep hours
-        return new Date((hours * 60 + offset) * 60000).toLocaleTimeString(Qt.locale(), qsTr("h:mm"))
+        var hour = ("00" + Math.floor(hours)).slice(-2),
+            minute = ("00" + Math.floor((hours - Math.floor(hours))*60)).slice(-2);
+
+        return hour + ":" + minute;
     }
 
     pageMenu: PageMenuPL {


### PR DESCRIPTION
This PR does two or three things.

I noticed from the sqlite DB that my GTR leaves very large gaps where nothing is recorded (like 3hrs in the night).
So I added `temp_sleep_ts` to track the last timestamp where a sleep has started, and instead of `time_sleep++` I added that `delta_seconds` to it (converted to minutes).

Also, because the deep sleep was skyrocketing, I pushed it back to only when the `delta_seconds` was exactly 1 minute and when `intensity` was 0.
 
After these changes, amazfish actually shows bigger sleep times and deep times than Zepp (most of the times. It still shows lower times once in a while). I tracked down the reason of actually including what seems to be afternoon sleep or late detection of wake-up time. I don't have a solution now, but my past week is not outragesly out of sync with Zepp.

Second change:
I noticed, while being in GMT+2, that the function converting hours floating point to hh:mm was getting different values if I switched to London (GMT+0). I thought to re-write it to not depend on locales etc.

Third-ish change:
While using the build instructions many files generated untracked git noise. I've added more ignores.