### PR TITLE
Fix Kirigami PageListPL

### DIFF
--- a/ui/qml/components/platform.kirigami/PageListPL.qml
+++ b/ui/qml/components/platform.kirigami/PageListPL.qml
@@ -24,10 +24,6 @@ import "."
 
 Kirigami.ScrollablePage {
     id: page
-    flickable: listView
-    mainItem: listView
-    Kirigami.ColumnView.fillWidth: false
-    Kirigami.Theme.colorSet: Kirigami.Theme.Window
 
     property string acceptIconName: styler.iconForward
     property alias  acceptText: mainAction.text
@@ -43,10 +39,6 @@ Kirigami.ScrollablePage {
     property var    pageMenu
     property bool   placeholderEnabled: true
     property string placeholderText
-
-    // hide all other items in this list
-    // to avoid interference with Kirigami Page
-    default property var _content
 
     signal pageStatusActivating
     signal pageStatusActive
@@ -72,7 +64,6 @@ Kirigami.ScrollablePage {
         id: listView
 
         currentIndex: -1
-        ScrollBar.vertical: ScrollBar {}
         header: Column {
             height: styler.themePaddingLarge +
                     (headerExtraLoader.height > 0 ? headerExtraLoader.height + styler.themePaddingLarge : 0)


### PR DESCRIPTION
The code contains a few things that are unnecessary and actually break
things.

Now the page properly fills the width and the scrollbar is placed
properly

Before:
![image](https://user-images.githubusercontent.com/6377822/122077885-6ed77a00-cdfc-11eb-9a84-a877f1ec7acb.png)

After:
![image](https://user-images.githubusercontent.com/6377822/122077779-523b4200-cdfc-11eb-9a78-4217692c8d48.png)
