### PR TITLE
Fix Support Feature Weather

### DIFF
--- a/ui/qml/pages/Settings-menu.qml
+++ b/ui/qml/pages/Settings-menu.qml
@@ -44,10 +44,10 @@ PageListPL {
 
         function checkFeature() {
             if(name === qsTr("Alarms")) {
-                return supportsFeature(Amazfish.FEATURE_WEATHER)
+                return supportsFeature(Amazfish.FEATURE_ALARMS)
             }
             else if (name === qsTr("Weather")) {
-                return supportsFeature(Amazfish.FEATURE_ALARMS)
+                return supportsFeature(Amazfish.FEATURE_WEATHER)
             }
             else {
                 return true


### PR DESCRIPTION
If device supports Alarms, it enables weather as a supported feature. If device supports Weather it enables feature Alarms.

This fixes the qml transposition. 