### PR TITLE
Add support for the upload procedure of external resource for the PineTime (running InfiniTime).

### DIFF
--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -46,7 +46,7 @@ WATCHFISH_FEATURES += music \
                   calendar
 }
 
-INCLUDEPATH += /usr/include/mkcal-qt5 /usr/include/KF5/KCalendarCore
+INCLUDEPATH += /usr/include/mkcal-qt5 /usr/include/KF5/KCalendarCore /usr/include/KF5/KArchive
 
 INCLUDEPATH += $$PWD/src/services/ \
                $$PWD/src/operations/ \
@@ -111,11 +111,14 @@ SOURCES += \
     src/devices/gtsdevice.cpp \
     src/devices/gtsfirmwareinfo.cpp \
     src/devices/pinetimejfdevice.cpp \
+    src/operations/adafruitblefsoperation.cpp \
+    src/operations/adafruitblefsworker.cpp \
     src/operations/dfuoperation.cpp \
     src/operations/dfuworker.cpp \
     src/operations/updatefirmwareoperationnew.cpp \
     src/operations/huamiupdatefirmwareoperation2020.cpp \
     src/qaesencryption.cpp \
+    src/services/adafruitblefsservice.cpp \
     src/services/currenttimeservice.cpp \
     src/services/dfuservice.cpp \
     src/services/infinitimemotionservice.cpp \
@@ -178,11 +181,14 @@ HEADERS += \
     src/devices/gtsdevice.h \
     src/devices/gtsfirmwareinfo.h \
     src/devices/pinetimejfdevice.h \
+    src/operations/adafruitblefsoperation.h \
+    src/operations/adafruitblefsworker.h \
     src/operations/dfuoperation.h \
     src/operations/dfuworker.h \
     src/operations/updatefirmwareoperationnew.h \
     src/operations/huamiupdatefirmwareoperation2020.h \
     src/qaesencryption.h \
+    src/services/adafruitblefsservice.h \
     src/services/currenttimeservice.h \
     src/services/dfuservice.h \
     src/services/infinitimemotionservice.h \

--- a/daemon/src/devices/infinitimefirmwareinfo.cpp
+++ b/daemon/src/devices/infinitimefirmwareinfo.cpp
@@ -44,7 +44,6 @@ void InfinitimeFirmwareInfo::determineFirmwareType()
                 qDebug() << "Resource file detected";
                 m_type = Res_Compressed;
             }
-
         }
     }
 }

--- a/daemon/src/devices/infinitimefirmwareinfo.cpp
+++ b/daemon/src/devices/infinitimefirmwareinfo.cpp
@@ -55,7 +55,10 @@ void InfinitimeFirmwareInfo::determineFirmwareVersion()
     case Firmware:
         m_version = "FW ()";
         break;
-    default:
+    case Res_Compressed:
         m_version = "Ressource ()";
+        break;
+    default:
+        m_version = "unknown";
     }
 }

--- a/daemon/src/devices/infinitimefirmwareinfo.cpp
+++ b/daemon/src/devices/infinitimefirmwareinfo.cpp
@@ -39,6 +39,12 @@ void InfinitimeFirmwareInfo::determineFirmwareType()
                 qDebug() << "DFU file detected";
                 m_type = Firmware;
             }
+            else if(root->entry("resources.json") != nullptr)
+            {
+                qDebug() << "Resource file detected";
+                m_type = Res_Compressed;
+            }
+
         }
     }
 }
@@ -50,6 +56,6 @@ void InfinitimeFirmwareInfo::determineFirmwareVersion()
         m_version = "FW ()";
         break;
     default:
-        m_version = "unknown";
+        m_version = "Ressource ()";
     }
 }

--- a/daemon/src/devices/pinetimejfdevice.h
+++ b/daemon/src/devices/pinetimejfdevice.h
@@ -42,6 +42,7 @@ private:
     void parseServices();
     void initialise();
     Q_SLOT void serviceEvent(const QString &characteristic, uint8_t event);
+    AbstractFirmwareInfo::Type firmwareType;
 
 };
 

--- a/daemon/src/operations/adafruitblefsoperation.cpp
+++ b/daemon/src/operations/adafruitblefsoperation.cpp
@@ -1,0 +1,199 @@
+#include "adafruitblefsoperation.h"
+#include "adafruitblefsservice.h"
+#include "adafruitblefsworker.h"
+#include <QMetaType>
+
+AdafruitBleFsOperation::AdafruitBleFsOperation(QBLEService *service, const AbstractFirmwareInfo *info) : AbstractOperation(service), info{info}
+{
+
+}
+
+AdafruitBleFsOperation::~AdafruitBleFsOperation()
+{
+
+}
+
+void AdafruitBleFsOperation::start()
+{
+
+}
+
+bool AdafruitBleFsOperation::handleMetaData(const QByteArray &value)
+{
+  return true;
+}
+
+void AdafruitBleFsOperation::handleData(const QByteArray &data)
+{
+    const uint8_t cmdId = data[0];
+
+    switch(cmdId) {
+    case RESPONSE_LIST_DIR:
+        handleListDirectory(data);
+        break;
+    case RESPONSE_DELETE_FILE:
+        handleDeleteFile(data);
+        break;
+    case RESPONSE_WRITE_FILE:
+        handleWriteFile(data);
+        break;
+    default:
+        break;
+    }
+}
+
+void AdafruitBleFsOperation::handleListDirectory(const QByteArray &value)
+{
+    uint8_t status = value[1];
+    uint16_t pathSize = value[2] + (value[3] << 8);
+    uint32_t entryNr = value[4] + (value[5] << 8) + (value[6] << 16) + (value[7] << 24);
+    uint32_t entryTotal = value[8] + (value[9] << 8) + (value[10] << 16) + (value[11] << 24);
+    uint32_t flags = value[12] + (value[13] << 8) + (value[14] << 16) + (value[15] << 24);
+    bool isDirectory = (flags & 0x01) == 1;
+    uint64_t timestamp = value[16] + (value[17] << 8) + (value[18] << 16) + (value[19] << 24)
+            + + ((uint64_t)value[20] << 32) + + ((uint64_t)value[21] << 40) + + ((uint64_t)value[22] << 48) + + ((uint64_t)value[23] << 56);
+    uint32_t fileSize = value[24] + (value[25] << 8) + (value[26] << 16) + (value[27] << 24);
+    std::string filename;
+    filename += '/';
+    for(int i = 0; i < pathSize; i++) {
+        filename += (char)value[28+i];
+    }
+    filename[pathSize] = 0;
+
+    if(entryNr == 0)
+    {
+        listDirectoryEntries.clear();
+    }
+    File f {filename, timestamp, isDirectory};
+    listDirectoryEntries.push_back(f);
+
+    if(entryNr == entryTotal)
+    {
+        listDirectoryPromise.set_value(listDirectoryEntries);
+    }
+}
+
+void AdafruitBleFsOperation::handleDeleteFile(const QByteArray &value)
+{
+    deleteFilePromise.set_value();
+}
+
+void AdafruitBleFsOperation::handleWriteFile(const QByteArray &value)
+{
+    uint8_t status = value[1];
+    uint32_t offset = (uint32_t)value[4] + ((uint32_t)value[5] << 8) + ((uint32_t)value[6] << 16) + ((uint32_t)value[7] << 24);
+    uint64_t timestamp = value[8] + (value[9] << 8) + (value[10] << 16) + (value[11] << 24) + ((uint64_t)value[12] << 32) + ((uint64_t)value[13] << 40) + ((uint64_t)value[14] << 48) + ((uint64_t)value[15] << 56);
+    uint32_t freeSpace = value[16] + (value[17] << 8) + (value[18] << 16) + (value[19] << 24);
+
+    writeFilePromise.set_value(freeSpace);
+}
+
+std::future<std::vector<AdafruitBleFsOperation::File>> AdafruitBleFsOperation::listDirectory()
+{
+    this->listDirectoryPromise = std::promise<std::vector<File>>();
+
+    QByteArray cmd;
+    cmd += REQUEST_LIST_DIR;
+    cmd += PADDING_BYTE;
+    cmd += (uint8_t)1;
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)'/';
+    m_service->writeValue(AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER, cmd);
+
+    return listDirectoryPromise.get_future();
+}
+
+std::future<void> AdafruitBleFsOperation::eraseFile(const std::string& filename)
+{
+    deleteFilePromise = std::promise<void>();
+
+    QByteArray cmd;
+    cmd += REQUEST_DELETE_FILE;
+    cmd += PADDING_BYTE;
+    cmd += (uint8_t)(filename.size() & 0xff);
+    cmd += (uint8_t)((filename.size() >> 8) & 0xff);
+    for(int i = 0; i < filename.size(); i++) {
+        cmd += filename[i];
+    }
+    m_service->writeValue(AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER, cmd);
+
+    return deleteFilePromise.get_future();
+}
+
+std::future<size_t> AdafruitBleFsOperation::writeFileStart(const std::string& filePath, size_t fileSize, size_t offset)
+{
+    writeFilePromise = std::promise<size_t>();
+
+    QByteArray cmd;
+    cmd += REQUEST_WRITE_FILE_START;
+    cmd += PADDING_BYTE;
+    cmd += (uint8_t)(filePath.size() & 0xff);
+    cmd += (uint8_t)((filePath.size() >> 8) & 0xff);
+    cmd += offset & 0xff;
+    cmd += (offset >> 8) & 0xff;
+    cmd += (offset >> 16) & 0xff;
+    cmd += (offset >> 24) & 0xff;
+    cmd += (uint8_t)0; // timestamp
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)0;
+    cmd += (uint8_t)0;
+    cmd += fileSize & 0xff;
+    cmd += (fileSize >> 8) & 0xff;
+    cmd += (fileSize >> 16) & 0xff;
+    cmd += (fileSize >> 24) & 0xff;
+    for(int i = 0; i < filePath.size(); i++)
+    {
+        cmd += filePath[i];
+    }
+    m_service->writeValue(AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER, cmd);
+
+    return writeFilePromise.get_future();
+}
+
+std::future<size_t> AdafruitBleFsOperation::writeFileData(const std::vector<uint8_t> data, size_t offset)
+{
+    writeFilePromise = std::promise<size_t>();
+
+    QByteArray cmd;
+    cmd += REQUEST_WRITE_FILE_DATA;
+    cmd += (uint8_t)0x01;
+    cmd += PADDING_BYTE;
+    cmd += PADDING_BYTE;
+    cmd += offset & 0xff;
+    cmd += (offset >> 8) & 0xff;
+    cmd += (offset >> 16) & 0xff;
+    cmd += (offset >> 24) & 0xff;
+    cmd += data.size() & 0xff;
+    cmd += (data.size() >> 8) & 0xff;
+    cmd += (data.size() >> 16) & 0xff;
+    cmd += (data.size() >> 24) & 0xff;
+    for(int i = 0; i < data.size(); i++)
+    {
+        cmd += data[i];
+    }
+
+    m_service->writeValue(AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER, cmd);
+
+    return writeFilePromise.get_future();
+}
+
+void AdafruitBleFsOperation::updateFiles(const int mtu)
+{
+    if(m_worker == nullptr)
+    {
+        m_worker = new BleFsWorker(info);
+        m_worker->moveToThread(&m_workerThread);
+        QObject::connect(&m_workerThread, &QThread::finished, m_worker, &QObject::deleteLater);
+        QObject::connect(this, &AdafruitBleFsOperation::startUpdateFiles, m_worker, &BleFsWorker::updateFiles);
+        m_workerThread.start();
+    }
+    emit startUpdateFiles(this, mtu);
+}
+
+void AdafruitBleFsOperation::downloadProgress(int percent) {
+    emit dynamic_cast<AdafruitBleFsService*>(m_service)->downloadProgress(percent);
+}

--- a/daemon/src/operations/adafruitblefsoperation.h
+++ b/daemon/src/operations/adafruitblefsoperation.h
@@ -23,10 +23,12 @@ public:
         bool isDirectory;
     };
 
+
     std::future<std::vector<File>> listDirectory(const std::string& path);
     std::future<void> eraseFile(const std::string& file);
-    std::future<size_t> writeFileStart(const std::string& filePath, size_t fileSize, size_t offset);
-    std::future<size_t> writeFileData(const std::vector<uint8_t> data, size_t offset);
+    std::future<bool> writeFileStart(const std::string& filePath, size_t fileSize, size_t offset);
+    std::future<bool> writeFileData(const std::vector<uint8_t> data, size_t offset);
+    std::future<bool> createDirectory(const std::string& path);
 
     void updateFiles(const int mtu);
     void downloadProgress(int percent);
@@ -40,10 +42,19 @@ private:
     static const uint8_t RESPONSE_DELETE_FILE = 0x31;
     static const uint8_t REQUEST_LIST_DIR = 0x50;
     static const uint8_t RESPONSE_LIST_DIR = 0x51;
+    static const uint8_t REQUEST_CREATE_DIR = 0x40;
+    static const uint8_t RESPONSE_CREATE_DIR = 0x41;
+
+    enum class Status : uint8_t {
+        Success = 0x01,
+        Error = 0x02,
+        ReadOnly = 0x05
+    };
 
     void handleListDirectory(const QByteArray &data);
     void handleDeleteFile(const QByteArray &data);
     void handleWriteFile(const QByteArray &data);
+    void handleCreateDirectory(const QByteArray &data);
 
     const AbstractFirmwareInfo *info;
 
@@ -51,7 +62,8 @@ private:
 
     std::promise<std::vector<File>> listDirectoryPromise;
     std::promise<void> deleteFilePromise;
-    std::promise<size_t> writeFilePromise;
+    std::promise<bool> writeFilePromise;
+    std::promise<bool> createDirectoryPromise;
 
     QThread m_workerThread;
     BleFsWorker* m_worker = nullptr;

--- a/daemon/src/operations/adafruitblefsoperation.h
+++ b/daemon/src/operations/adafruitblefsoperation.h
@@ -23,7 +23,7 @@ public:
         bool isDirectory;
     };
 
-    std::future<std::vector<File>> listDirectory();
+    std::future<std::vector<File>> listDirectory(const std::string& path);
     std::future<void> eraseFile(const std::string& file);
     std::future<size_t> writeFileStart(const std::string& filePath, size_t fileSize, size_t offset);
     std::future<size_t> writeFileData(const std::vector<uint8_t> data, size_t offset);

--- a/daemon/src/operations/adafruitblefsoperation.h
+++ b/daemon/src/operations/adafruitblefsoperation.h
@@ -1,0 +1,62 @@
+#ifndef ADAFRUITBLEFSOPERATION_H
+#define ADAFRUITBLEFSOPERATION_H
+
+#include "abstractoperation.h"
+#include "abstractfirmwareinfo.h"
+
+class AdafruitBleFsService;
+class BleFsWorker;
+
+class AdafruitBleFsOperation : public QObject, public AbstractOperation
+{
+    Q_OBJECT
+public:
+    AdafruitBleFsOperation(QBLEService *service, const AbstractFirmwareInfo *info);
+    ~AdafruitBleFsOperation();
+    bool handleMetaData(const QByteArray &meta) override;
+    void handleData(const QByteArray &data) override;
+    void start() override;
+
+    struct File {        
+        std::string name;
+        uint64_t timestamp;
+        bool isDirectory;
+    };
+
+    std::future<std::vector<File>> listDirectory();
+    std::future<void> eraseFile(const std::string& file);
+    std::future<size_t> writeFileStart(const std::string& filePath, size_t fileSize, size_t offset);
+    std::future<size_t> writeFileData(const std::vector<uint8_t> data, size_t offset);
+
+    void updateFiles(const int mtu);
+    void downloadProgress(int percent);
+
+private:
+    static const uint8_t PADDING_BYTE = 0x00;
+    static const uint8_t REQUEST_WRITE_FILE_START = 0x20;
+    static const uint8_t RESPONSE_WRITE_FILE = 0x21;
+    static const uint8_t REQUEST_WRITE_FILE_DATA = 0x22;
+    static const uint8_t REQUEST_DELETE_FILE = 0x30;
+    static const uint8_t RESPONSE_DELETE_FILE = 0x31;
+    static const uint8_t REQUEST_LIST_DIR = 0x50;
+    static const uint8_t RESPONSE_LIST_DIR = 0x51;
+
+    void handleListDirectory(const QByteArray &data);
+    void handleDeleteFile(const QByteArray &data);
+    void handleWriteFile(const QByteArray &data);
+
+    const AbstractFirmwareInfo *info;
+
+    std::vector<File> listDirectoryEntries;
+
+    std::promise<std::vector<File>> listDirectoryPromise;
+    std::promise<void> deleteFilePromise;
+    std::promise<size_t> writeFilePromise;
+
+    QThread m_workerThread;
+    BleFsWorker* m_worker = nullptr;
+
+    Q_SIGNAL void startUpdateFiles(AdafruitBleFsOperation* service, const int mtu);
+};
+
+#endif // ADAFRUITBLEFSOPERATION_H

--- a/daemon/src/operations/adafruitblefsworker.cpp
+++ b/daemon/src/operations/adafruitblefsworker.cpp
@@ -1,0 +1,153 @@
+#include "adafruitblefsworker.h"
+#include "adafruitblefsservice.h"
+#include "adafruitblefsoperation.h"
+#include <KArchive>
+#include <kzip.h>
+#include <KCompressionDevice>
+
+namespace
+{
+    KZip openArchive(QByteArray& bytes)
+    {
+        QDataStream in(&bytes, QIODevice::ReadOnly);
+        KCompressionDevice dev(in.device(), false, KCompressionDevice::CompressionType::None);
+        KZip zip(&dev);
+        return std::move(zip);
+    }
+
+    const KArchiveDirectory* getArchiveRootDirectory(KZip& zip)
+    {
+        if(!zip.open(QIODevice::ReadOnly))
+        {
+            return nullptr;
+        }
+
+        auto* root = zip.directory();
+        auto list = root->entries();
+        return root;
+    }
+
+    size_t getTotalSize(const QJsonArray& resourceList, const KArchiveDirectory* root)
+    {
+        size_t totalSize = 0;
+        for(const QJsonValue& resource : resourceList) {
+            auto sourceFile = resource["filename"].toString();
+            auto* resourceEntry = dynamic_cast<const KZipFileEntry*>(root->entry(sourceFile));
+            totalSize += resourceEntry->size();
+        }
+        return totalSize;
+    }
+
+    bool fileExists(std::vector<AdafruitBleFsOperation::File> list, QString name)
+    {
+        auto it = std::find_if(list.begin(), list.end(), [name](const AdafruitBleFsOperation::File& f)
+        {
+            return f.name == name.toStdString();
+        });
+
+        return it != list.end();
+    }
+}
+
+BleFsWorker::BleFsWorker(const AbstractFirmwareInfo *info, QObject *parent) : QObject(parent), info{info}
+{
+
+}
+
+
+BleFsWorker::~BleFsWorker()
+{
+
+}
+
+
+
+void BleFsWorker::updateFiles(AdafruitBleFsOperation* service, int transferMtu)
+{
+    // Open ZIP file
+    auto archiveBytes = info->bytes();
+
+    QDataStream in(&archiveBytes, QIODevice::ReadOnly);
+    KCompressionDevice dev(in.device(), false, KCompressionDevice::CompressionType::None);
+    KZip zip(&dev);
+
+    auto* archiveRoot = getArchiveRootDirectory(zip);
+    if(archiveRoot == nullptr)
+    {
+        return;
+    }
+
+    auto archiveEntries = archiveRoot->entries();
+    if(!archiveEntries.contains("resources.json"))
+        return;
+
+    // Get manifest file data from the archive
+    auto* manifestEntry = dynamic_cast<const KZipFileEntry*>(archiveRoot->entry("resources.json"));
+    auto manifestData = manifestEntry->data();
+
+    // Open manifest file and parse JSON
+    QJsonDocument manifestDocument = QJsonDocument::fromJson(manifestData);
+    QJsonObject manifestObject = manifestDocument.object();
+    auto resourceList = manifestObject["resources"].toArray();
+
+    // Get total size to be uploaded
+    auto totalSize = getTotalSize(resourceList, archiveRoot);
+
+    // List directory from the watch
+    auto fileList = getRemoteFileList(service);
+
+
+    // Upload the resources
+    int progressSize = 0;
+    for(const QJsonValue& resource : resourceList)
+    {
+        auto sourceFile = resource["filename"].toString();
+        auto destinationFile = resource["path"].toString();
+
+        if(fileExists(fileList, destinationFile))
+        {
+            eraseRemoteFile(service, destinationFile);
+        }
+
+        auto* resourceEntry = dynamic_cast<const KZipFileEntry*>(archiveRoot->entry(sourceFile));
+        auto resourceData = resourceEntry->data();
+
+        auto writeFileFuture = service->writeFileStart(destinationFile.toStdString(), resourceData.size(), 0);
+        writeFileFuture.wait();
+
+        const size_t chunkSize = transferMtu-20;
+        size_t written = 0;
+        while(written < resourceData.size())
+        {
+            std::vector<uint8_t> chunk;
+            size_t remaining = resourceData.size() - written;
+            size_t toWrite = std::min(remaining, chunkSize);
+            for(int i = 0; i < toWrite; i++)
+            {
+                chunk.push_back(resourceData.at(written + i));
+            }
+
+            auto writeFileDataFuture = service->writeFileData(chunk, written);
+            writeFileDataFuture.wait();
+            writeFileDataFuture.get();
+
+            written += toWrite;
+            progressSize += toWrite;
+            service->downloadProgress((100.0f / totalSize) * progressSize);
+        }
+    }
+}
+
+std::vector<AdafruitBleFsOperation::File> BleFsWorker::getRemoteFileList(AdafruitBleFsOperation* service)
+{
+    auto listDirectoryFuture = service->listDirectory();
+    listDirectoryFuture.wait();
+    return listDirectoryFuture.get();
+
+}
+
+void BleFsWorker::eraseRemoteFile(AdafruitBleFsOperation* service, QString file)
+{
+    auto eraseFileFuture = service->eraseFile(file.toStdString());
+    eraseFileFuture.wait();
+}

--- a/daemon/src/operations/adafruitblefsworker.h
+++ b/daemon/src/operations/adafruitblefsworker.h
@@ -15,7 +15,7 @@ public:
     ~BleFsWorker();
 
 private:
-    std::vector<AdafruitBleFsOperation::File> getRemoteFileList(AdafruitBleFsOperation* service);
+    std::vector<AdafruitBleFsOperation::File> getRemoteFileList(AdafruitBleFsOperation* service, QString path);
     void eraseRemoteFile(AdafruitBleFsOperation* service, QString file);
 
     bool m_interupted = false;

--- a/daemon/src/operations/adafruitblefsworker.h
+++ b/daemon/src/operations/adafruitblefsworker.h
@@ -1,0 +1,31 @@
+#ifndef ADAFRUITBLEFSWORKER_H
+#define ADAFRUITBLEFSWORKER_H
+
+#include <QObject>
+#include "abstractfirmwareinfo.h"
+#include "adafruitblefsoperation.h"
+
+class AdafruitBleFsService;
+
+class BleFsWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BleFsWorker(const AbstractFirmwareInfo *info, QObject *parent = nullptr);
+    ~BleFsWorker();
+
+private:
+    std::vector<AdafruitBleFsOperation::File> getRemoteFileList(AdafruitBleFsOperation* service);
+    void eraseRemoteFile(AdafruitBleFsOperation* service, QString file);
+
+    bool m_interupted = false;
+    const AbstractFirmwareInfo *info;
+
+public slots:
+    void updateFiles(AdafruitBleFsOperation* service, int mtu);
+
+signals:
+    void done();
+};
+
+#endif // ADAFRUITBLEFSWORKER_H

--- a/daemon/src/operations/adafruitblefsworker.h
+++ b/daemon/src/operations/adafruitblefsworker.h
@@ -17,6 +17,7 @@ public:
 private:
     std::vector<AdafruitBleFsOperation::File> getRemoteFileList(AdafruitBleFsOperation* service, QString path);
     void eraseRemoteFile(AdafruitBleFsOperation* service, QString file);
+    bool createParentFolder(AdafruitBleFsOperation* service, QStringList folderList);
 
     bool m_interupted = false;
     const AbstractFirmwareInfo *info;

--- a/daemon/src/services/adafruitblefsservice.cpp
+++ b/daemon/src/services/adafruitblefsservice.cpp
@@ -1,0 +1,36 @@
+#include "adafruitblefsservice.h"
+
+const char* AdafruitBleFsService::UUID_SERVICE_FS = "0000febb-0000-1000-8000-00805f9b34fb";
+const char* AdafruitBleFsService::UUID_CHARACTERISTIC_FS_VERSION = "adaf0100-4669-6c65-5472-616e73666572";
+const char* AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER = "adaf0200-4669-6c65-5472-616e73666572";
+
+AdafruitBleFsService::AdafruitBleFsService(const QString &path, QObject *parent, size_t mtu) : QBLEService(UUID_SERVICE_FS, path, parent), mtu(mtu)
+{
+    qDebug() << Q_FUNC_INFO;
+
+    connect(this, &QBLEService::characteristicChanged, this, &AdafruitBleFsService::characteristicChanged);
+    enableNotification(UUID_CHARACTERISTIC_FS_TRANSFER);
+}
+
+void AdafruitBleFsService::prepareDownload(AdafruitBleFsOperation* operation)
+{
+    this->operation = operation;
+}
+
+
+void AdafruitBleFsService::updateFiles()
+{
+    operation->updateFiles(mtu);
+}
+
+
+void AdafruitBleFsService::characteristicChanged(const QString &characteristic, const QByteArray &value)
+{
+    qDebug() << Q_FUNC_INFO << characteristic << value;
+
+    if (characteristic == AdafruitBleFsService::UUID_CHARACTERISTIC_FS_VERSION) {
+        qDebug() << "Version : " << (value[0] + (value[1] << 8));
+    } else {
+        operation->handleData(value);
+    }
+}

--- a/daemon/src/services/adafruitblefsservice.h
+++ b/daemon/src/services/adafruitblefsservice.h
@@ -1,0 +1,35 @@
+#ifndef ADAFRUITBLEFSSERVICE_H
+#define ADAFRUITBLEFSSERVICE_H
+
+#include "qble/qbleservice.h"
+#include "adafruitblefsoperation.h"
+
+/*
+{0000febb-0000-1000-8000-00805f9b34fb} FS Service
+--adaf0100-4669-6c65-5472-616e73666572 // Version
+--adaf0200-4669-6c65-5472-616e73666572 // transfer
+*/
+
+class AdafruitBleFsService : public QBLEService
+{
+    Q_OBJECT
+
+public:
+    AdafruitBleFsService(const QString &path, QObject *parent, size_t mtu);
+    static const char *UUID_SERVICE_FS;
+    static const char *UUID_CHARACTERISTIC_FS_VERSION;
+    static const char *UUID_CHARACTERISTIC_FS_TRANSFER;
+
+    void prepareDownload(AdafruitBleFsOperation* operation);
+    void updateFiles();
+
+    Q_SIGNAL void downloadProgress(int percent);
+
+private:
+    Q_SLOT void characteristicChanged(const QString &characteristic, const QByteArray &value);
+
+    AdafruitBleFsOperation* operation = nullptr;
+    const size_t mtu;
+};
+
+#endif // ADAFRUITBLEFSSERVICE_H

--- a/daemon/src/services/infinitimeresourceservice.cpp
+++ b/daemon/src/services/infinitimeresourceservice.cpp
@@ -1,0 +1,21 @@
+#include "infinitimeresourceservice.h"
+
+InfiniTimeResourceService::InfiniTimeResourceService(AdafruitBleFsService* fsService) : fsService{fsService}
+{
+
+}
+
+void InfiniTimeResourceService::listDirectory() {
+    qDebug() << "TEST4";
+    auto p = fsService->listDirectory();
+
+    p.wait();
+    auto l = p.get();
+    qDebug() << "Received " << l.size() << "files";
+    for(auto& f : l) {
+        qDebug() << "\n\t" << (f.isDirectory ? "Directory" : "File") << " : " << f.name
+                 << "\n\t Timestamp : " << f.timestamp;
+
+
+    }
+}

--- a/daemon/src/services/infinitimeresourceservice.h
+++ b/daemon/src/services/infinitimeresourceservice.h
@@ -1,0 +1,17 @@
+#ifndef INFINITIMERESOURCESERVICE_H
+#define INFINITIMERESOURCESERVICE_H
+
+#include "adafruitblefsservice.h"
+#include "qble/qbleservice.h"
+
+class InfiniTimeResourceService :  public QBLEService {
+public:
+    InfiniTimeResourceService(AdafruitBleFsService* fsService);
+
+    void listDirectory();
+
+private:
+    AdafruitBleFsService* fsService = nullptr;
+};
+
+#endif // INFINITIMERESOURCESERVICE_H

--- a/ui/qml/pages/PairSelectDeviceType.qml
+++ b/ui/qml/pages/PairSelectDeviceType.qml
@@ -15,7 +15,7 @@ PageListPL {
                     var pairpage = pageStack.push(Qt.resolvedUrl("./PairPage.qml"));
                     pairpage.deviceType = deviceType;})
             } else {
-                var pairpage = pageStack.push(Qt.resolvedUrl("/home/jf/git/harbour-amazfish/ui/qml/pages/PairPage.qml"));
+                var pairpage = pageStack.push(Qt.resolvedUrl("./PairPage.qml"));
                 pairpage.deviceType = deviceType;
             }
         }

--- a/ui/qml/pages/PairSelectDeviceType.qml
+++ b/ui/qml/pages/PairSelectDeviceType.qml
@@ -15,7 +15,7 @@ PageListPL {
                     var pairpage = pageStack.push(Qt.resolvedUrl("./PairPage.qml"));
                     pairpage.deviceType = deviceType;})
             } else {
-                var pairpage = pageStack.push(Qt.resolvedUrl("./PairPage.qml"));
+                var pairpage = pageStack.push(Qt.resolvedUrl("/home/jf/git/harbour-amazfish/ui/qml/pages/PairPage.qml"));
                 pairpage.deviceType = deviceType;
             }
         }


### PR DESCRIPTION
At InfiniTime, we are working on adding support for external resources : applications and watchfaces will be able to load images and fonts stored in the external SPI flash memory of the PineTime.

This is working quite well. See [here](https://github.com/InfiniTimeOrg/InfiniTime/issues/321) and [here](https://github.com/InfiniTimeOrg/InfiniTime/pull/1226).

Those resources are packaged into a ZIP file together with a "manifest file" that describes the mapping of the files into the watch. See [here](https://github.com/InfiniTimeOrg/InfiniTime/issues/1285).

Now, we need companion apps to implement the [upload procedure](https://github.com/InfiniTimeOrg/InfiniTime/issues/1285#issuecomment-1221605579) so users can easily update the resources from their device.

This PR contains the implementation of the Adafruit BLE File Transfer Protocol (the BLE FS API implemented in InfiniTime) and of the upload procedure specified for InfiniTime.

Note that the feature is not merged yet in InfiniTime, we are still doing some tests and waiting for other companion apps to add this feature.

Basically, this PR add `AdafruitBleFsService` which is the entry point for the Adafruit BLE File Transfer Protocol, `AdafruitBleFsService` which contains operations on the API (list, erase, write file) and `AdafruitBleFsWorker` which implements the upload procedure.