### PR TITLE
PineTime / InfiniTime : OTA now takes the DFU ZIP file

### DIFF
--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -14,7 +14,7 @@ TARGET = harbour-amazfishd
 
 LIBS += -Lqble/qble -L$$OUT_PWD/../lib -lamazfish -lz
 PKGCONFIG += dbus-1
-QT +=  positioning KDb3 network dbus
+QT +=  positioning KDb3 network dbus KArchive
 CONFIG += c++14
 
 equals(FLAVOR, "silica") {

--- a/daemon/src/devices/infinitimefirmwareinfo.h
+++ b/daemon/src/devices/infinitimefirmwareinfo.h
@@ -13,8 +13,8 @@ private:
     void determineFirmwareType();
     void determineFirmwareVersion();
 
-    const uint8_t FW_HEADER[4]{ // DFU Zip file
-            0x3D, 0xB8, 0xF3, 0x96
+    const uint8_t ZIP_HEADER[4]{ // Zip file
+            0x50, 0x4b, 0x03, 0x04
     };
 };
 

--- a/daemon/src/operations/dfuoperation.h
+++ b/daemon/src/operations/dfuoperation.h
@@ -33,6 +33,7 @@ private:
 
     Q_SIGNAL void sendFirmware(DfuService* service, const QByteArray &data, int notificationPackets);
     Q_SLOT void packetNotification();
+    bool probeArchive();
 };
 
 #endif // DFUOPERATION_H

--- a/daemon/src/operations/dfuoperation.h
+++ b/daemon/src/operations/dfuoperation.h
@@ -18,7 +18,7 @@ public:
 protected:
 
     const AbstractFirmwareInfo *m_info = nullptr;
-    QByteArray m_fwBytes;
+    QByteArray m_uncompressedFwBytes;
 
     virtual bool sendFwInfo();
     virtual void sendFirmwareData();
@@ -29,6 +29,7 @@ private:
     bool m_transferError = false;
     QThread m_workerThread;
     DfuWorker *m_worker = nullptr;
+    uint16_t m_crc16;
 
     Q_SIGNAL void sendFirmware(DfuService* service, const QByteArray &data, int notificationPackets);
     Q_SLOT void packetNotification();


### PR DESCRIPTION
In Infinitime, the firmware (for the OTA) is provided as a DFU ZIP file. However, Amazfish does not support the ZIP file and only accept the uncompressed binary file.

This PR adds support for the ZIP file (and removes the support for the raw bin file). The name of the firmware file inside the archive and the CRC of the firmware are read from the `manifest.json` file included in the DFU archive.