### PR TITLE
Fix error management in DfuService (for PineTime/InfiniTime)

### DIFF
--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -249,7 +249,7 @@ void PinetimeJFDevice::prepareFirmwareDownload(const AbstractFirmwareInfo *info)
 {
     DfuService *fw = qobject_cast<DfuService*>(service(DfuService::UUID_SERVICE_DFU));
     if (fw){
-        fw->prepareFirmwareDownload(info, new DfuOperation(info, fw));
+        fw->prepareFirmwareDownload(info);
     }
 }
 

--- a/daemon/src/operations/dfuoperation.cpp
+++ b/daemon/src/operations/dfuoperation.cpp
@@ -138,7 +138,7 @@ void DfuOperation::start()
         m_service->writeValue(DfuService::UUID_CHARACTERISTIC_DFU_CONTROL, UCHAR_TO_BYTEARRAY(DfuService::COMMAND_PACKET_RECEIPT_NOTIFICATION_REQUEST) + QByteArray(1, m_notificationPackets));
 
     } else {
-        m_service->message(QObject::tr("File does not seem to be supported"));
+        emit transferError("File does not seem to be supported");
     }
 }
 

--- a/daemon/src/operations/dfuoperation.h
+++ b/daemon/src/operations/dfuoperation.h
@@ -2,9 +2,10 @@
 #define DFUOPERATION_H
 
 #include "abstractoperation.h"
-#include "bipfirmwareinfo.h"
 #include "dfuworker.h"
 
+class DfuService;
+class AbstractFirmwareInfo;
 class DfuOperation : public QObject, public AbstractOperation
 {
     Q_OBJECT
@@ -15,8 +16,8 @@ public:
     void handleData(const QByteArray &data) override;
     void start() override;
 
+    Q_SIGNAL void transferError(const QString error);
 protected:
-
     const AbstractFirmwareInfo *m_info = nullptr;
     QByteArray m_uncompressedFwBytes;
 
@@ -32,6 +33,7 @@ private:
     uint16_t m_crc16;
 
     Q_SIGNAL void sendFirmware(DfuService* service, const QByteArray &data, int notificationPackets);
+
     Q_SLOT void packetNotification();
     bool probeArchive();
 };

--- a/daemon/src/operations/dfuworker.cpp
+++ b/daemon/src/operations/dfuworker.cpp
@@ -1,4 +1,8 @@
 #include "dfuworker.h"
+#include "qdebug.h"
+
+#include <QThread>
+#include "dfuservice.h"
 
 DfuWorker::DfuWorker(QObject *parent) : QObject(parent)
 {

--- a/daemon/src/operations/dfuworker.h
+++ b/daemon/src/operations/dfuworker.h
@@ -2,8 +2,8 @@
 #define DFUWORKER_H
 
 #include <QObject>
-#include "dfuservice.h"
 
+class DfuService;
 class DfuWorker : public QObject
 {
     Q_OBJECT

--- a/daemon/src/services/dfuservice.h
+++ b/daemon/src/services/dfuservice.h
@@ -1,9 +1,10 @@
 #ifndef DFUSERVICE_H
 #define DFUSERVICE_H
 
+#include <memory>
 #include "qble/qbleservice.h"
 #include "abstractfirmwareinfo.h"
-
+#include "dfuoperation.h"
 /*
 {00001530-1212-EFDE-1523-785FEABCD123} DFU Service
 --00001531-1212-EFDE-1523-785FEABCD123 //Control Point
@@ -47,7 +48,7 @@ public:
     static constexpr uint8_t ERROR_CRC_ERROR = 0x05;
     static constexpr uint8_t ERROR_OPERATION_FAILED = 0x06;
 
-    void prepareFirmwareDownload(const AbstractFirmwareInfo *info, DfuOperation* operation);
+    void prepareFirmwareDownload(const AbstractFirmwareInfo *info);
     void startDownload();
     Q_SIGNAL void downloadProgress(int percent);
 
@@ -59,9 +60,10 @@ public:
 
 private:
     Q_SLOT void characteristicChanged(const QString &characteristic, const QByteArray &value);
+    Q_SLOT void onTransferError(const QString error);
 
     int m_operationRunning = 0;
-    DfuOperation *m_updateFirmware = nullptr;
+    std::unique_ptr<DfuOperation> m_updateFirmware = nullptr;
     std::atomic<bool> m_waitForWatch;
 };
 


### PR DESCRIPTION
If an error occurs during the OTA for the PineTime running InfiniTime, the variable `m_operationRunning` is still set to 1, which prevents the user from restarting the transfer.
This PR fixes that by adding a new signal `DfuOperation::transferError`. When emitted, the slot in `DfuService::onTransferError` correctly sets the variable to 0.

I also took the opportunity to store `m_updateFirmware` in a unique_ptr to ensure that it's correctly destroyed in every cases.