### PR TITLE
Refactor notification application icon

### DIFF
--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -15,7 +15,7 @@ TARGET = harbour-amazfishd
 LIBS += -Lqble/qble -L$$OUT_PWD/../lib -lamazfish -lz
 PKGCONFIG += dbus-1
 QT +=  positioning KDb3 network dbus KArchive
-CONFIG += c++14
+CONFIG += c++17
 
 equals(FLAVOR, "silica") {
     CONFIG += flavor_silica

--- a/daemon/src/services/alertnotificationservice.cpp
+++ b/daemon/src/services/alertnotificationservice.cpp
@@ -68,32 +68,13 @@ int AlertNotificationService::mapSenderToIcon(const QString &sender)
     if (mailREX.exactMatch(s)) {
             return HuamiIcon::EMAIL;
     }
-    if (s == "facebook") {
-        return HuamiIcon::FACEBOOK;
-    }
-    if (s == "twitter" || s == "tweetian" || s == "piepmatz") {
-        return HuamiIcon::TWITTER;
-    }
-    if (s == "messenger") {
-        return HuamiIcon::FACEBOOK_MESSENGER;
-    }
-    if (s == "snapchat") {
-        return HuamiIcon::SNAPCHAT;
-    }
-    if (s == "whatsapp") {
-        return HuamiIcon::WHATSAPP;
-    }
-    if (s == "instagram") {
-        return HuamiIcon::INSTAGRAM;
-    }
-    if (s == "telegram" || s == "fernschreiber" || s == "yottagram" || s == "sailorgram" || s == "depecher") {
-        return HuamiIcon::TELEGRAM;
-    }
-    if (s == "skype") {
-        return HuamiIcon::SKYPE;
-    }
 
-    return HuamiIcon::APP_11;
+    auto icon = AppToIconMap.find(s);
+
+    if ( icon == AppToIconMap.end() )
+        return HuamiIcon::APP_11;
+
+    return icon->second;
 }
 
 void AlertNotificationService::characteristicChanged(const QString &c, const QByteArray &value)

--- a/daemon/src/services/alertnotificationservice.h
+++ b/daemon/src/services/alertnotificationservice.h
@@ -89,6 +89,31 @@ public:
     };
     Q_ENUM(AlertEvent)
 
+    static inline std::map<QString, HuamiIcon> AppToIconMap = {
+        /* Facebook */
+        {"facebook", HuamiIcon::FACEBOOK},
+        /* Facebook Messenger */
+        {"messenger", HuamiIcon::FACEBOOK_MESSENGER},
+        /* Instagram */
+        {"instagram", HuamiIcon::INSTAGRAM},
+        /* Telegram clients */
+        {"depecher", HuamiIcon::TELEGRAM},
+        {"fernschreiber", HuamiIcon::TELEGRAM},
+        {"sailorgram", HuamiIcon::TELEGRAM},
+        {"telegram", HuamiIcon::TELEGRAM},
+        {"yottogram", HuamiIcon::TELEGRAM},
+        /* Twitter Clients */
+        {"piepmatz", HuamiIcon::TWITTER},
+        {"tweetian", HuamiIcon::TWITTER},
+        {"twitter", HuamiIcon::TWITTER},
+        /* Snapchat */
+        {"snapchat", HuamiIcon::SNAPCHAT},
+        /* Skype */
+        {"skype", HuamiIcon::SKYPE},
+        /* WhatsApp */
+        {"whatsapp", HuamiIcon::WHATSAPP},
+    };
+
     Q_INVOKABLE void sendAlert(const QString &sender, const QString &subject, const QString &message);
     Q_INVOKABLE void incomingCall(const QString &caller);
     static int mapSenderToIcon(const QString &sender);


### PR DESCRIPTION
The change should make it easier to add aliases for common apps that
either don't have icons or are related to those that have predefined
icons.