### PR TITLE
Current Time Service : add 1 missing data byte

### DIFF
--- a/daemon/src/services/currenttimeservice.cpp
+++ b/daemon/src/services/currenttimeservice.cpp
@@ -20,7 +20,8 @@ void CurrentTimeService::setCurrentTime()
     timeBytes += TypeConversion::fromInt8(now.time().hour());
     timeBytes += TypeConversion::fromInt8(now.time().minute());
     timeBytes += TypeConversion::fromInt8(now.time().second());
-    timeBytes += char(0); //fractions of seconds
+    timeBytes += char(0); //day of week
+    timeBytes += char(0); //fractions256
     timeBytes += char(0); //reason
 
     qDebug() << "setting time to:" << now << timeBytes.toHex();


### PR DESCRIPTION
Add one missing data byte (fractions256) to be compliant with the BLE spec (CTS).

This change is needed to support [InfiniTime 1.12](https://github.com/InfiniTimeOrg/InfiniTime/releases/tag/1.12.0) which also [added this field and now requires 10 bytes to validate the data coming from the host](https://github.com/InfiniTimeOrg/InfiniTime/commit/38092fcb40695098702163ab64a06787b2dc2499).

BLE spec can be found [here (look for Current Time Service)](https://www.bluetooth.com/specifications/specs/current-time-service-1-1/) and [here (GATT Specification supplement)](https://www.bluetooth.com/specifications/assigned-numbers/).