### PR TITLE
Send title separated by 0x00 from rest of notifications

### DIFF
--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -140,7 +140,7 @@ void PinetimeJFDevice::parseServices()
             } else if (uuid == CurrentTimeService::UUID_SERVICE_CURRENT_TIME  && !service(CurrentTimeService::UUID_SERVICE_CURRENT_TIME)) {
                 addService(CurrentTimeService::UUID_SERVICE_CURRENT_TIME, new CurrentTimeService(path, this));
             } else if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION  && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this, 0x0a));
+                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
             } else if (uuid == PineTimeMusicService::UUID_SERVICE_MUSIC  && !service(PineTimeMusicService::UUID_SERVICE_MUSIC  )) {
                 addService(PineTimeMusicService::UUID_SERVICE_MUSIC  , new PineTimeMusicService(path, this));
             } else if (uuid == DfuService::UUID_SERVICE_DFU && !service(DfuService::UUID_SERVICE_DFU)) {


### PR DESCRIPTION
amazfish introduced configurable separator in February 2021 https://github.com/piggz/harbour-amazfish/commit/0638cc79c93682ea88721bf402324995775ba48f

infinitime introduced 0x00 separator for notification content in April 2021
https://github.com/InfiniTimeOrg/InfiniTime/commit/03de1c67393fcb99b5987514be6f470349c57c0f

Using 0x00 separator will improve layout notifications in PineTime. See screenshots.

![image20231008_133151313](https://github.com/piggz/harbour-amazfish/assets/6171637/3f1c3b1f-e80c-4400-bdd0-385bf31dfa76)
![image20231008_133158210](https://github.com/piggz/harbour-amazfish/assets/6171637/f3835527-ca4e-4223-a9a7-b44969a966de)
