### PR TITLE
Clarify Ubuntu Touch build instructions

### DIFF
--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,18 +1,20 @@
 clickable_minimum_required: 8.0.0
 framework: ubuntu-sdk-20.04
+
+prebuild: git submodule update --init
+kill: harbour-amazfish
+ignore_review_errors: true
+
 builder: qmake
 build_args:
-  - "FLAVOR=uuitk"
-  - "CONFIG+=click"
-  - "DISABLE_SYSTEMD=yes"
-  - "INCLUDEPATH+=${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5/MprisQt"
-  - "INCLUDEPATH+=${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5"
-  - "LIBS+=-L${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}"
+- FLAVOR=uuitk
+- CONFIG+=click
+- DISABLE_SYSTEMD=yes
+- INCLUDEPATH+=${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5/MprisQt
+- INCLUDEPATH+=${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5
+- LIBS+=-L${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}
 env_vars:
-  PKG_CONFIG_PATH: "${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/pkgconfig:${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/pkgconfig"
-  QMAKE_CXXFLAGS: "-I${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5 -I${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5/MprisQt"
-prebuild:
-- git submodule update --init
+  PKG_CONFIG_PATH: ${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/pkgconfig:${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/pkgconfig
 dependencies_target:
 - libkdb3-driver-sqlite
 - qml-module-org-kde-bluezqt
@@ -21,26 +23,30 @@ dependencies_target:
 - libkf5archive-dev
 - libkf5coreaddons-dev
 - libdbus-1-dev
-kill: harbour-amazfish
+
 libraries:
-    qtmpris:
-        prebuild: mkdir -p ${ROOT}/3rdparty; git -C ${ROOT}/3rdparty/qtmpris pull ||  git clone https://github.com/sailfishos/qtmpris ${ROOT}/3rdparty/qtmpris
-        src_dir: 3rdparty/qtmpris
-        builder: qmake
-    nemo-qml-plugin-dbus:
-        prebuild: mkdir -p ${ROOT}/3rdparty; git -C ${ROOT}/3rdparty/nemo-qml-plugin-dbus pull ||  git clone https://github.com/sailfishos/nemo-qml-plugin-dbus ${ROOT}/3rdparty/nemo-qml-plugin-dbus
-        src_dir: 3rdparty/nemo-qml-plugin-dbus
-        builder: qmake
+  qtmpris:
+    src_dir: 3rdparty/qtmpris
+    prebuild:
+    - mkdir -p ${ROOT}/3rdparty
+    - git -C ${SRC_DIR} pull || git clone https://github.com/sailfishos/qtmpris ${SRC_DIR}
+    builder: qmake
+
+  nemo-qml-plugin-dbus:
+    src_dir: 3rdparty/nemo-qml-plugin-dbus
+    prebuild:
+    - mkdir -p ${ROOT}/3rdparty
+    - git -C ${SRC_DIR} pull || git clone https://github.com/sailfishos/nemo-qml-plugin-dbus ${SRC_DIR}
+    builder: qmake
+
 install_lib:
-    - ${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/libnemodbus.so*
-    - ${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/libmpris-qt5.so*
-    - /usr/lib/${ARCH_TRIPLET}/libKDb3.so*
-    - /usr/lib/${ARCH_TRIPLET}/libKF5BluezQt.so*
+- libnemodbus.so*
+- libmpris-qt5.so*
+- libKDb3.so*
+- libKF5BluezQt.so*
 install_data:
-    /usr/lib/${ARCH_TRIPLET}/qt5/plugins/kdb3/kdb_sqlitedriver.so: bin/kdb3
-    /usr/lib/${ARCH_TRIPLET}/qt5/plugins/kdb3/sqlite3/kdb_sqlite_icu.so: bin/kdb3/sqlite3
+  /usr/lib/${ARCH_TRIPLET}/qt5/plugins/kdb3: bin
 install_qml:
-    - ${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/Nemo/DBus
-    - ${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/org/nemomobile/mpris
-    - /usr/lib/${ARCH_TRIPLET}/qt5/qml/org/kde/bluezqt
-skip_review: true
+- ${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/Nemo/DBus
+- ${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/org/nemomobile/mpris
+- /usr/lib/${ARCH_TRIPLET}/qt5/qml/org/kde/bluezqt

--- a/documentation/build-instructions.md
+++ b/documentation/build-instructions.md
@@ -1,4 +1,6 @@
-# This instruction guide is written for the SailfishOS SDK and Ubuntu 20.04 LTS, but may be also available for other Linux distributions, with some changes.
+# Build Instructions
+
+This instruction guide is written for the SailfishOS SDK and Debian based distributions including Ubuntu Touch, but may be also available for other Linux distributions, with some changes.
 
 ## SailfishOS SDK
 
@@ -135,27 +137,20 @@ systemctl --user start harbour-amazfish
 
 ## Ubuntu Touch
 
-Ubuntu 20.04 is the preferred base system for installing the SDK because the current version of UBports also runs on Ubuntu 20.04. The steps to install the SDK are as follows:
-
-```
-sudo add apt-repository ppa:bhdouglass/clickable
-sudo apt update
-sudo apt install clickable
-clickable setup
-```
-
-To build and develop applications on x86 architecture, use the following commands:
+Clickable is used to build this app for Ubuntu Touch, see [install instructions](https://clickable-ut.dev/en/latest/install.html).
+To build and run the application in Desktop Mode for testing the UI, use the following commands:
 
 ```
 clickable build --libs
-clickable build
 clickable desktop
 ```
 
 To build the application for ARM architecture and install it on your device, follow these steps:
 
 ```
-clickable build --libs --arch arm64
-clickable build --arch arm64
-clickable install --arch arm64
+clickable build --libs --arch detect
+clickable build --arch detect
+clickable install
 ```
+
+If you do not have a device connected, you can specify the target architecture as `--arch arm64` or `--arch armhf` instead.


### PR DESCRIPTION
This PR clarifies the Ubuntu Touch build instructions, mainly:

- there is no need to run Ubuntu in order to build an app for Ubuntu Touch
- the recommended and better portable way of installation is via pip, not ppa
- little clean up of clickable.yaml for better readability