### PR TITLE
fix build with ubports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Requires Sailfish version 3.0.3.8 or above due to changes in the base Sailfish i
 * Run `devel-su pkcon refresh`
 * Run `devel-su pkcon install harbour-amazfish`
 
+
+[![OpenStore](https://open-store.io/badges/en_US.svg)](https://open-store.io/app/uk.co.piggz.amazfish)
+
 ## Supported Devices
 
 There are 3 tiers of supported devices:

--- a/click/manifest.json.in
+++ b/click/manifest.json.in
@@ -1,5 +1,5 @@
 {
-    "name": "harbour-amazfish",
+    "name": "uk.co.piggz.amazfish",
     "description": "Smart watch sync app",
     "architecture": "@CLICK_ARCH@",
     "title": "Amazfish",

--- a/click/run.sh
+++ b/click/run.sh
@@ -12,10 +12,10 @@ Description=Amazfish daemon
 After=graphical.target
 
 [Service]
-ExecStart=/opt/click.ubuntu.com/harbour-amazfish/current/bin/harbour-amazfishd
+ExecStart=/opt/click.ubuntu.com/uk.co.piggz.amazfish/current/bin/harbour-amazfishd
 Restart=always
 RestartSec=5
-Environment=LD_LIBRARY_PATH=/opt/click.ubuntu.com/harbour-amazfish/current/lib:/opt/click.ubuntu.com/harbour-amazfish/current/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
+Environment=LD_LIBRARY_PATH=/opt/click.ubuntu.com/uk.co.piggz.amazfish/current/lib:/opt/click.ubuntu.com/uk.co.piggz.amazfish/current/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
 Environment=HOME=%h XDG_CONFIG_HOME=/home/%u/.config DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus XDG_RUNTIME_DIR=/run/user/%U
 
 [Install]

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -40,10 +40,10 @@ libraries:
     builder: qmake
 
 install_lib:
-- libnemodbus.so*
-- libmpris-qt5.so*
-- libKDb3.so*
-- libKF5BluezQt.so*
+- ${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/libnemodbus.so*
+- ${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/libmpris-qt5.so*
+- /usr/lib/${ARCH_TRIPLET}/libKDb3.so*
+- /usr/lib/${ARCH_TRIPLET}/libKF5BluezQt.so*
 install_data:
   /usr/lib/${ARCH_TRIPLET}/qt5/plugins/kdb3: bin
 install_qml:

--- a/ui/ui.pro
+++ b/ui/ui.pro
@@ -205,7 +205,11 @@ equals(DISABLE_SYSTEMD, "yes") {
     DEFINES += DISABLE_SYSTEMD
 }
 
-DEFINES += TRANSLATION_FOLDER=\\\"$${PREFIX}/share/$${TARGET}/translations\\\"
+flavor_uuitk {
+    DEFINES += TRANSLATION_FOLDER=\\\"./translations\\\"
+} else {
+    DEFINES += TRANSLATION_FOLDER=\\\"$${PREFIX}/share/$${TARGET}/translations\\\"
+}
 
 flavor_silica {
     message(SailfishOS build)
@@ -233,7 +237,6 @@ flavor_silica {
 flavor_uuitk {
     message(UUITK build)
     DEFINES += UUITK_EDITION
-    DEFINES += TRANSLATION_FOLDER=\\\"./translations\\\"
 
     qtPrepareTool(LRELEASE, lrelease)
     for(tsfile, TRANSLATIONS) {


### PR DESCRIPTION
setting application name to uk.co.piggz.amazfish, because This is the unique  for your app. It must match exactly the "name" field in your click's manifest.json and must be all lowercase letters. For example: "openstore.openstore-team", where "openstore" is the app and "openstore-team" is the group or individual authoring the app. see https://open-store.io/submit

fix TRANSLATION folder, because follwing error message in logs <command-line>: warning: "TRANSLATION_FOLDER" redefined <command-line>: note: this is the location of the previous definition

The clickable.yaml must contain whole path, otherwise build reports following error message:
Files to install not found with pattern "libKDb3.so*"