### PR TITLE
Improve weather ux

### DIFF
--- a/lib/src/weather/currentweather.h
+++ b/lib/src/weather/currentweather.h
@@ -109,6 +109,8 @@ public:
     QString language() const;
     void setLanguage(const QString &language);
 
+    Q_PROPERTY(int temperature READ temperature NOTIFY ready)
+
     int temperature() const;
     int minTemperature() const;
     int maxTemperature() const;

--- a/ui/qml/pages/AddCityPage.qml
+++ b/ui/qml/pages/AddCityPage.qml
@@ -9,6 +9,9 @@ PagePL {
 
     property CityManager cityManager
 
+    property string currentCity: (cityManager !== null) &&
+        (cityManager.cities.length > 0) ? (cityManager.cities[0].name + ", " +  cityManager.cities[0].country ) : '' 
+
     Column {
         id: column
         anchors.fill: parent
@@ -17,6 +20,11 @@ PagePL {
 
         CitySearchModel {
             id: citymodel
+        }
+
+        LabelPL {
+            text: page.currentCity
+            visible: page.currentCity !== ""
         }
 
         SearchFieldPL {

--- a/ui/qml/pages/AddCityPage.qml
+++ b/ui/qml/pages/AddCityPage.qml
@@ -12,6 +12,18 @@ PagePL {
     property string currentCity: (cityManager !== null) &&
         (cityManager.cities.length > 0) ? (cityManager.cities[0].name + ", " +  cityManager.cities[0].country ) : '' 
 
+    CurrentWeather {
+        id: weather
+    }
+
+    onCurrentCityChanged: {
+        if ((cityManager == null) || (cityManager.cities.length <= 0)) {
+            return
+        }
+        weather.setCity(cityManager.cities[0])
+        weather.refresh()
+    }
+
     Column {
         id: column
         anchors.fill: parent
@@ -23,7 +35,9 @@ PagePL {
         }
 
         LabelPL {
-            text: page.currentCity
+            text: page.currentCity + (
+                (weather.temperature !== 0) ? " " + (weather.temperature-273) + "˚C" : ""
+            )
             visible: page.currentCity !== ""
         }
 

--- a/ui/src/harbour-amazfish-ui.cpp
+++ b/ui/src/harbour-amazfish-ui.cpp
@@ -23,6 +23,7 @@
 #include "weather/citysearchmodel.h"
 #include "weather/citymanager.h"
 #include "weather/city.h"
+#include "weather/currentweather.h"
 
 #include "trackloader.h"
 #include "amazfishconfig.h"
@@ -92,6 +93,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<CitySearchModel>("org.SfietKonstantin.weatherfish", 1, 0, "CitySearchModel");
     qmlRegisterType<CityManager>("org.SfietKonstantin.weatherfish", 1, 0, "CityManager");
     qmlRegisterType<City>("org.SfietKonstantin.weatherfish", 1, 0, "City");
+    qmlRegisterType<CurrentWeather>("org.SfietKonstantin.weatherfish", 1, 0, "CurrentWeather");
     qmlRegisterType<TrackLoader>("uk.co.piggz.amazfish", 1, 0, "TrackLoader");
     qmlRegisterType<AdapterModel>("uk.co.piggz.amazfish", 1, 0, "AdapterModel");
     qmlRegisterType<O2>("com.pipacs.o2", 1, 0, "O2");


### PR DESCRIPTION
I wasn't sure which city is currently configured in the layout. I have extended the dialog to display the current city name and current temperature, as shown in the screenshot below:

![Screenshot from 2023-10-15 10-28-28](https://github.com/piggz/harbour-amazfish/assets/6171637/25edaefa-ac7c-45af-937e-fa0758ff0258)

There can also be a prefix such as 'Current city.' Personally, I think it is enough to display just the city name.

```
LabelPL {
  text: qsTr("Current city: %1 %2")
     .arg(page.currentCity)
     .arg((weather.temperature !== 0) ? " " + (weather.temperature-273) + "˚C" : "")
}
```

Additionally, an icon can be added and displayed on the same line, for example, using icons from https://erikflowers.github.io/weather-icons/