### PR TITLE
There was missing first letter in notification

### DIFF
--- a/daemon/src/devices/huamidevice.cpp
+++ b/daemon/src/devices/huamidevice.cpp
@@ -137,7 +137,7 @@ void HuamiDevice::incomingCall(const QString &caller)
     qDebug() << Q_FUNC_INFO << caller;
     AlertNotificationService *alert = qobject_cast<AlertNotificationService*>(service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION));
     if (alert) {
-        alert->incomingCall(caller);
+        alert->incomingCall(QByteArray::fromHex("0301"), caller);
     }
 }
 

--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -100,7 +100,7 @@ void PinetimeJFDevice::incomingCall(const QString &caller)
     qDebug() << Q_FUNC_INFO << caller;
     AlertNotificationService *alert = qobject_cast<AlertNotificationService*>(service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION));
     if (alert) {
-        alert->incomingCall(caller);
+        alert->incomingCall(QByteArray::fromHex("030100"), caller);
     }
 }
 

--- a/daemon/src/services/alertnotificationservice.cpp
+++ b/daemon/src/services/alertnotificationservice.cpp
@@ -53,6 +53,7 @@ void AlertNotificationService::incomingCall(const QString &caller)
 {
     qDebug() << Q_FUNC_INFO << caller;
     QByteArray send = QByteArray::fromHex("0301");
+    send += QByteArray(1, 1);
     send += caller.toUtf8();
     writeValue(UUID_CHARACTERISTIC_ALERT_NOTIFICATION_NEW_ALERT, send);
 }

--- a/daemon/src/services/alertnotificationservice.cpp
+++ b/daemon/src/services/alertnotificationservice.cpp
@@ -49,11 +49,10 @@ void AlertNotificationService::sendAlert(const QString &sender, const QString &s
     writeValue(UUID_CHARACTERISTIC_ALERT_NOTIFICATION_NEW_ALERT, send);
 }
 
-void AlertNotificationService::incomingCall(const QString &caller)
+void AlertNotificationService::incomingCall(const QByteArray header, const QString &caller)
 {
     qDebug() << Q_FUNC_INFO << caller;
-    QByteArray send = QByteArray::fromHex("030100");
-    send += caller.toUtf8();
+    QByteArray send = header + caller.toUtf8();
     writeValue(UUID_CHARACTERISTIC_ALERT_NOTIFICATION_NEW_ALERT, send);
 }
 

--- a/daemon/src/services/alertnotificationservice.cpp
+++ b/daemon/src/services/alertnotificationservice.cpp
@@ -52,8 +52,7 @@ void AlertNotificationService::sendAlert(const QString &sender, const QString &s
 void AlertNotificationService::incomingCall(const QString &caller)
 {
     qDebug() << Q_FUNC_INFO << caller;
-    QByteArray send = QByteArray::fromHex("0301");
-    send += QByteArray(1, 1);
+    QByteArray send = QByteArray::fromHex("030100");
     send += caller.toUtf8();
     writeValue(UUID_CHARACTERISTIC_ALERT_NOTIFICATION_NEW_ALERT, send);
 }

--- a/daemon/src/services/alertnotificationservice.h
+++ b/daemon/src/services/alertnotificationservice.h
@@ -115,7 +115,7 @@ public:
     };
 
     Q_INVOKABLE void sendAlert(const QString &sender, const QString &subject, const QString &message);
-    Q_INVOKABLE void incomingCall(const QString &caller);
+    Q_INVOKABLE void incomingCall(const QByteArray header, const QString &caller);
     static int mapSenderToIcon(const QString &sender);
 
     Q_SIGNAL void serviceEvent(const QString &c, uint8_t event);


### PR DESCRIPTION
I am not sure if this works properly also on other smartwatches, but on PineTime this definitely helps. 

It seems generic alert message is used for phone call, but it is composed in different way. 
The alert is
category (one byte ) + alert_type=1 ( one byte ) + icon(one byte)  + sender (32 bytes) + separator (one byte) +subject (128bytes) + separator=\n (two bytes) + message (128bytes)

PineTime doesn't counts lenght sender+subject+message, together and clips it to 100 bytes

The incommingCall() composes message like this
03 01 + caller_id
I believe that header should be 3 bytes (I have added 0x01 for icon)
03 01 01 + caller_id

And finally  proof with picture:

![image20231017_181829517](https://github.com/piggz/harbour-amazfish/assets/6171637/cf419eac-e99d-4b19-b437-f6eb7599e69c)
![image20231017_181836912](https://github.com/piggz/harbour-amazfish/assets/6171637/64fab498-4e0c-4236-b859-18750822d016)

The notification was send from debug dialog.