### PR TITLE
Enable systemd in Ubuntu Touch

### DIFF
--- a/click/run.sh
+++ b/click/run.sh
@@ -37,12 +37,6 @@ else
         /usr/bin/systemctl --user restart harbour-amazfish.service
     fi
 
-    # start if not running
-
-    if ! systemctl is-active --user harbour-amazfish; then
-        /usr/bin/systemctl --user start harbour-amazfish.service
-    fi
-
 fi
 
 export LD_LIBRARY_PATH=$PWD/lib:$PWD/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -9,7 +9,6 @@ builder: qmake
 build_args:
 - FLAVOR=uuitk
 - CONFIG+=click
-- DISABLE_SYSTEMD=yes
 - INCLUDEPATH+=${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5/MprisQt
 - INCLUDEPATH+=${QTMPRIS_LIB_INSTALL_DIR}/usr/include/${ARCH_TRIPLET}/qt5
 - LIBS+=-L${QTMPRIS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}


### PR DESCRIPTION
Actually there is no reason to disable systemd. Daemon is started as systemd --user unit. The only difference is that unit lives in $HOME/.config/systemd/user/harbour-amazfish.service 