### PR TITLE
Single menu item must have icon in Ubuntu Touch

### DIFF
--- a/ui/qml/components/DownloadDataMenuItem.qml
+++ b/ui/qml/components/DownloadDataMenuItem.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import "platform"
 
 PageMenuItemPL {
+    iconSource: styler.iconDownloadData !== undefined ? styler.iconDownloadData : ""
     text: qsTr("Download Data")
     onClicked: DaemonInterfaceInstance.downloadActivityData()
     enabled: DaemonInterfaceInstance.connectionState === "authenticated"

--- a/ui/qml/components/platform.uuitk/PageMenuItemPL.qml
+++ b/ui/qml/components/platform.uuitk/PageMenuItemPL.qml
@@ -21,7 +21,7 @@ import QtQuick.Controls 2.2
 import Lomiri.Components 1.3 as UC
 
 UC.Action {
-    iconSource: iconName
+    iconName: iconSource
     signal clicked
     onTriggered: clicked()
 }

--- a/ui/qml/components/platform.uuitk/StylerPL.qml
+++ b/ui/qml/components/platform.uuitk/StylerPL.qml
@@ -64,6 +64,9 @@ QtObject {
     property string iconHeartrate: "../../pics/custom-icons/icon-m-heartrate.png"
 
 
+    property string iconStravaLogin: "image://theme/user-admin"
+    property string iconUploadToStrava: "image://theme/share"
+    property string iconDownloadData: "image://theme/transfer-progress-download"
     property string iconAbout: "image://theme/info" //Qt.resolvedUrl("../../icons/help-about-symbolic.svg")
     property string iconBack: "image://theme/back" //Qt.resolvedUrl("../../icons/go-previous-symbolic.svg")
     property string iconBackward: "image://theme/back"

--- a/ui/qml/pages/DebugInfo.qml
+++ b/ui/qml/pages/DebugInfo.qml
@@ -12,6 +12,7 @@ PagePL {
 
     pageMenu: PageMenuPL {
         PageMenuItemPL {
+            iconSource: styler.iconRefresh !== undefined ? styler.iconRefresh : ""
             text: qsTr("Refresh")
             onClicked: {
                 DaemonInterfaceInstance.refreshInformation();

--- a/ui/qml/pages/SportPage.qml
+++ b/ui/qml/pages/SportPage.qml
@@ -26,6 +26,7 @@ PagePL {
     pageMenu: PageMenuPL {
         PageMenuItemPL
         {
+            iconSource: styler.iconUploadToStrava !== undefined ? styler.iconUploadToStrava : ""
             text: qsTr("Send to Strava")
             visible: o2strava.linked
             onClicked: {

--- a/ui/qml/pages/SportsSummaryPage.qml
+++ b/ui/qml/pages/SportsSummaryPage.qml
@@ -10,6 +10,7 @@ PageListPL {
 
     pageMenu: PageMenuPL {
         PageMenuItemPL {
+            iconSource: styler.iconDownloadData !== undefined ? styler.iconDownloadData : ""
             text: qsTr("Download Next Activity")
             onClicked: DaemonInterfaceInstance.downloadSportsData();
             enabled: DaemonInterfaceInstance.connectionState === "authenticated"

--- a/ui/qml/pages/StravaSettingsPage.qml
+++ b/ui/qml/pages/StravaSettingsPage.qml
@@ -32,6 +32,7 @@ PagePL {
         PageMenuItemPL
         {
             id: btnAuth
+            iconSource: styler.iconStravaLogin !== undefined ? styler.iconStravaLogin : ""
             text: o2strava.linked ? qsTr("Logout") : qsTr("Login")
             onClicked: {
                 if (o2strava.linked) {


### PR DESCRIPTION
The menus in ubuntu touch containing only one item collapses into action button without label. The button is not visible without icon.

For example the refresh MenuItem on DebugInfo Page looks like this after changed:

![screenshot20231023_074917750](https://github.com/piggz/harbour-amazfish/assets/6171637/7e7bd84f-5efe-4d0d-85ca-ddce89db1faf)

Additionally, the iconSource in [PageMenuItemPL.qml](https://github.com/piggz/harbour-amazfish/compare/master...jmlich:singleMenuItem?expand=1#diff-8f2ebc8656ea33b5f58d6510f9b46224d8b3d899d56d6838a80fb2be25d00841) must be done other way around in order to work at least with current release with Ubuntu Touch.

The icons are set in order to keep working SailfishOS port even when the icon is not set. This is a case of following icons
```
    property string iconStravaLogin: "image://theme/user-admin"
    property string iconUploadToStrava: "image://theme/share"
    property string iconDownloadData: "image://theme/transfer-progress-download"
```
The only MenuItem which will be different on all 4 flavors is refresh item on DebugInfo Page, because refresh icon already exists in Styler component.