### PR TITLE
downloadProgress should report also 100%

### DIFF
--- a/daemon/src/operations/adafruitblefsworker.cpp
+++ b/daemon/src/operations/adafruitblefsworker.cpp
@@ -177,6 +177,7 @@ void BleFsWorker::updateFiles(AdafruitBleFsOperation* service, int transferMtu)
             service->downloadProgress((100.0f / totalSize) * progressSize);
         }
     }
+    service->downloadProgress(100.0f);
 }
 
 std::vector<AdafruitBleFsOperation::File> BleFsWorker::getRemoteFileList(AdafruitBleFsOperation* service, QString path)


### PR DESCRIPTION
Current implementation reports progress only during upload, but not after the transfer is finished.

The condition `while (written < resourceData.size())` does not cover the `written == resourceData.size()` case.

WIP: I need to test it better. I am very sure that progress indicator shows 99% and pinetime already reboots. 