### PR TITLE
fetchLogs not accessible from ui

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -855,6 +855,13 @@ void DeviceInterface::enableFeature(int feature)
     }
 }
 
+void DeviceInterface::fetchLogs()
+{
+    if (miBandService()) {
+        miBandService()->fetchLogs();
+    }
+}
+
 QStringList DeviceInterface::supportedDisplayItems()
 {
     qDebug() << Q_FUNC_INFO;

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -76,6 +76,7 @@ public:
     Q_INVOKABLE void updateCalendar();
     Q_INVOKABLE void reloadCities();
     Q_INVOKABLE void enableFeature(int feature);
+    Q_INVOKABLE void fetchLogs();
     Q_INVOKABLE QStringList supportedDisplayItems();
 
 private:

--- a/ui/qml/pages/DebugInfo.qml
+++ b/ui/qml/pages/DebugInfo.qml
@@ -166,7 +166,7 @@ PagePL {
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width * 0.8
             onClicked: {
-                DaemonInterfaceInstance.miBandService().fetchLogs();
+                DaemonInterfaceInstance.fetchLogs();
             }
         }
         ButtonPL {

--- a/ui/src/daemoninterface.cpp
+++ b/ui/src/daemoninterface.cpp
@@ -323,6 +323,13 @@ void DaemonInterface::enableFeature(Amazfish::Feature feature)
     iface->call(QStringLiteral("enableFeature"), (int)feature);
 }
 
+void DaemonInterface::fetchLogs() {
+    if (!iface || !iface->isValid()) {
+        return;
+    }
+    iface->call(QStringLiteral("fetchLogs"));
+}
+
 QStringList DaemonInterface::supportedDisplayItems()
 {
     if (!iface || !iface->isValid()) {

--- a/ui/src/daemoninterface.h
+++ b/ui/src/daemoninterface.h
@@ -51,6 +51,7 @@ public:
     Q_INVOKABLE void updateCalendar();
     Q_INVOKABLE void reloadCities();
     Q_INVOKABLE void enableFeature(Amazfish::Feature feature);
+    Q_INVOKABLE void fetchLogs();
     Q_INVOKABLE QStringList supportedDisplayItems();
 
 public slots:


### PR DESCRIPTION
I was checking code of fetchLogs() and it seems that `DaemonInterfaceInstance.miBandService()` is not accessible in UI. In my opinion the code should be as is in pull request. However, I don't have a device to test.