### PR TITLE
Sampling of PineTime realtime activity and store it into mi_band_activity table

### DIFF
--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -130,6 +130,7 @@ SOURCES += \
     src/typeconversion.cpp \
     src/bipbatteryinfo.cpp \
     src/devicefactory.cpp \
+    src/realtimeactivitysample.cpp \
     src/services/mibandservice.cpp \
     src/services/miband2service.cpp \
     src/services/alertnotificationservice.cpp \
@@ -208,6 +209,7 @@ HEADERS += \
     src/activitysummary.h \ 
     src/activitysample.h \
     src/devicefactory.h \
+    src/realtimeactivitysample.h \
     src/services/mibandservice.h \
     src/services/miband2service.h \
     src/services/alertnotificationservice.h \

--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -397,6 +397,7 @@ void DeviceInterface::onConnectionStateChanged()
     qDebug() << "DeviceInterface::onConnectionStateChanged" << connectionState();
 
     if (connectionState() == "authenticated") {
+        m_device->setDatabase(dbConnection());
         if (miBandService()) {
             miBandService()->setDatabase(dbConnection());
             m_dbusHRM->setMiBandService(miBandService());

--- a/daemon/src/devices/abstractdevice.cpp
+++ b/daemon/src/devices/abstractdevice.cpp
@@ -86,6 +86,11 @@ bool AbstractDevice::supportsFeature(AbstractDevice::Feature f) const
     return (supportedFeatures() & f) == f;
 }
 
+void AbstractDevice::setDatabase(KDbConnection *conn)
+{
+    m_conn = conn;
+}
+
 QString AbstractDevice::deviceName() const
 {
     return m_pairedName;

--- a/daemon/src/devices/abstractdevice.h
+++ b/daemon/src/devices/abstractdevice.h
@@ -6,6 +6,11 @@
 #include "weather/currentweather.h"
 #include "abstractfirmwareinfo.h"
 
+#include <KDb3/KDbDriver>
+#include <KDb3/KDbConnection>
+#include <KDb3/KDbConnectionData>
+#include <KDb3/KDbTransactionGuard>
+
 class AbstractDevice : public QBLEDevice
 {
     Q_OBJECT
@@ -83,6 +88,8 @@ public:
     bool supportsFeature(Feature f) const;
     virtual int supportedFeatures() const = 0;
 
+    void setDatabase(KDbConnection *conn);
+
     virtual QString deviceType() const = 0;
     QString deviceName() const;
     virtual void abortOperations();
@@ -125,11 +132,13 @@ protected:
     QTimer *m_reconnectTimer;
 
     void setConnectionState(const QString &state);
+    KDbConnection *m_conn = nullptr;
 
 private:
     void reconnectionTimer();
     void devicePairFinished(const QString& status);
     QString m_pairedName;
+
 };
 
 #endif

--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -12,6 +12,8 @@
 #include "infinitimeweatherservice.h"
 #include "adafruitblefsservice.h"
 #include "batteryservice.h"
+#include "amazfishconfig.h"
+#include "realtimeactivitysample.h"
 #include <QtXml/QtXml>
 
 namespace {
@@ -209,6 +211,7 @@ void PinetimeJFDevice::initialise()
     HRMService *hrm = qobject_cast<HRMService*>(service(HRMService::UUID_SERVICE_HRM));
     if (hrm) {
         connect(hrm, &HRMService::informationChanged, this, &AbstractDevice::informationChanged, Qt::UniqueConnection);
+        connect(hrm, &HRMService::informationChanged, &realtimeActivitySample, &RealtimeActivitySample::slot_informationChanged, Qt::UniqueConnection);
     }
 
     InfiniTimeMotionService *motion = qobject_cast<InfiniTimeMotionService*>(service(InfiniTimeMotionService::UUID_SERVICE_MOTION));
@@ -216,13 +219,65 @@ void PinetimeJFDevice::initialise()
         motion->enableNotification(InfiniTimeMotionService::UUID_CHARACTERISTIC_MOTION_STEPS);
         //motion->enableNotification(InfiniTimeMotionService::UUID_CHARACTERISTIC_MOTION_MOTION);
         connect(motion, &InfiniTimeMotionService::informationChanged, this, &AbstractDevice::informationChanged, Qt::UniqueConnection);
+        connect(motion, &InfiniTimeMotionService::informationChanged, &realtimeActivitySample, &RealtimeActivitySample::slot_informationChanged, Qt::UniqueConnection);
     }
 
     AdafruitBleFsService *bleFs = qobject_cast<AdafruitBleFsService*>(service(AdafruitBleFsService::UUID_SERVICE_FS));
     if (bleFs) {
         connect(bleFs, &AdafruitBleFsService::downloadProgress, this, &PinetimeJFDevice::downloadProgress, Qt::UniqueConnection);
     }
+
+    connect(&realtimeActivitySample, &RealtimeActivitySample::samplesReady, this, &PinetimeJFDevice::sampledActivity, Qt::UniqueConnection);
 }
+
+void PinetimeJFDevice::sampledActivity(QDateTime dt, int kind, int intensity, int steps, int heartrate) {
+    qDebug() << Q_FUNC_INFO << dt << kind << intensity << steps << heartrate;
+
+
+    if (!m_conn || !(m_conn->isDatabaseUsed())) {
+        qDebug() << "Database not connected";
+        return;
+    }
+
+    auto config = AmazfishConfig::instance();
+    uint id = qHash(config->profileName());
+    uint devid = qHash(config->pairedAddress());
+
+    KDbTransaction transaction = m_conn->beginTransaction();
+    KDbTransactionGuard tg(transaction);
+
+    KDbFieldList fields;
+    auto mibandActivity = m_conn->tableSchema("mi_band_activity");
+
+    fields.addField(mibandActivity->field("timestamp"));
+    fields.addField(mibandActivity->field("timestamp_dt"));
+    fields.addField(mibandActivity->field("device_id"));
+    fields.addField(mibandActivity->field("user_id"));
+    fields.addField(mibandActivity->field("raw_intensity"));
+    fields.addField(mibandActivity->field("steps"));
+    fields.addField(mibandActivity->field("raw_kind"));
+    fields.addField(mibandActivity->field("heartrate"));
+
+    QList<QVariant> values;
+
+    values << dt.toMSecsSinceEpoch() / 1000;
+    values << dt;
+    values << devid;
+    values << id;
+    values << intensity;
+    values << steps;
+    values << kind;
+    values << heartrate;
+
+    if (!m_conn->insertRecord(&fields, values)) {
+        qWarning() << "error inserting record";
+        tg.rollback();
+        return;
+    }
+    tg.commit();
+
+}
+
 
 void PinetimeJFDevice::onPropertiesChanged(QString interface, QVariantMap map, QStringList list)
 {

--- a/daemon/src/devices/pinetimejfdevice.h
+++ b/daemon/src/devices/pinetimejfdevice.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include "abstractdevice.h"
+#include "realtimeactivitysample.h"
 
 class PinetimeJFDevice : public AbstractDevice
 {
@@ -43,6 +44,11 @@ private:
     void initialise();
     Q_SLOT void serviceEvent(const QString &characteristic, uint8_t event);
     AbstractFirmwareInfo::Type firmwareType;
+
+    RealtimeActivitySample realtimeActivitySample;
+
+    Q_SLOT void sampledActivity(QDateTime dt, int kind, int intensity, int steps, int heartrate);
+
 
 };
 

--- a/daemon/src/realtimeactivitysample.cpp
+++ b/daemon/src/realtimeactivitysample.cpp
@@ -41,32 +41,43 @@ void RealtimeActivitySample::setHeartrate(int _heartrate) {
 void RealtimeActivitySample::sampleUpdated() {
     QDateTime now = QDateTime::currentDateTime();
 
+
+    int steps_diff = 0;
+    int avg_heartrate = 0;
+
+    if (m_steps_previous == 0) {
+        m_steps_previous = m_steps;
+    }
+
+
+
     // send old data
     if (m_lastSync.secsTo(now) > m_interval) {
-        int steps_diff = 0;
+
         if ((m_steps_previous != 0) && (m_steps > m_steps_previous)) {
             steps_diff = m_steps - m_steps_previous;
         }
-        int avg_heartrate = 0;
+
         if (!m_heartrate_samples.isEmpty()) {
             for (int value : m_heartrate_samples) {
                 avg_heartrate += value;
             }
             avg_heartrate = avg_heartrate / m_heartrate_samples.size();
         }
-
         if ((m_intensity != 0) || (steps_diff != 0) || (avg_heartrate != 0)) {
             emit samplesReady(m_lastSync, m_kind, m_intensity, steps_diff, avg_heartrate);
+
+            // prepare for new data
+            m_kind = 0;
+            m_intensity = 0;
+            m_steps_previous = m_steps;
+            m_steps = 0;
+            m_heartrate_samples.clear();
+            m_lastSync = now;
+
         }
     }
 
-    // prepare for new data
-    m_kind = 0;
-    m_intensity = 0;
-    m_steps_previous = m_steps;
-    m_steps = 0;
-    m_heartrate_samples.clear();
-    m_lastSync = now;
 
 }
 

--- a/daemon/src/realtimeactivitysample.cpp
+++ b/daemon/src/realtimeactivitysample.cpp
@@ -1,0 +1,79 @@
+#include "realtimeactivitysample.h"
+
+#include <QDebug>
+
+RealtimeActivitySample::RealtimeActivitySample(QObject* parent) : QObject(parent) {
+    m_lastSync = QDateTime::currentDateTime();
+}
+
+void RealtimeActivitySample::setKind(int _kind) {
+    if (_kind == 0) {
+        return;
+    }
+    sampleUpdated();
+    m_kind = _kind;
+}
+
+void RealtimeActivitySample::setIntensity(int _intensity) {
+    if (_intensity == 0) {
+        return;
+    }
+    sampleUpdated();
+    m_intensity = _intensity;
+}
+
+void RealtimeActivitySample::setSteps(int _steps) {
+    if (_steps == 0) {
+        return;
+    }
+    sampleUpdated();
+    m_steps = _steps;
+}
+
+void RealtimeActivitySample::setHeartrate(int _heartrate) {
+    if (_heartrate == 0) {
+        return;
+    }
+    sampleUpdated();
+    m_heartrate_samples.push_back(_heartrate);
+}
+
+void RealtimeActivitySample::sampleUpdated() {
+    QDateTime now = QDateTime::currentDateTime();
+
+    if (m_lastSync.secsTo(now) > m_interval) {
+        if ((m_steps_previous != 0) && (m_steps > m_steps_previous)) {
+            int avg_heartrate = 0;
+            if (!m_heartrate_samples.isEmpty()) {
+                for (int value : m_heartrate_samples) {
+                    avg_heartrate += value;
+                }
+                avg_heartrate = avg_heartrate / m_heartrate_samples.size();
+
+            }
+            emit samplesReady(m_lastSync, m_kind, m_intensity, m_steps - m_steps_previous, avg_heartrate);
+        }
+        m_kind = 0;
+        m_intensity = 0;
+        m_steps_previous = m_steps;
+        m_steps = 0;
+        m_heartrate_samples.clear();
+        m_lastSync = now;
+    }
+}
+
+void RealtimeActivitySample::slot_informationChanged(AbstractDevice::Info infokey, const QString &infovalue) {
+
+    switch (infokey) {
+        case AbstractDevice::INFO_STEPS:
+            setSteps(infovalue.toInt());
+        break;
+        case AbstractDevice::INFO_HEARTRATE:
+            setHeartrate(infovalue.toInt());
+        break;
+        default:
+            qWarning() << Q_FUNC_INFO << "unexpeted key " << infokey;
+        break;
+    }
+
+}

--- a/daemon/src/realtimeactivitysample.cpp
+++ b/daemon/src/realtimeactivitysample.cpp
@@ -41,25 +41,33 @@ void RealtimeActivitySample::setHeartrate(int _heartrate) {
 void RealtimeActivitySample::sampleUpdated() {
     QDateTime now = QDateTime::currentDateTime();
 
+    // send old data
     if (m_lastSync.secsTo(now) > m_interval) {
+        int steps_diff = 0;
         if ((m_steps_previous != 0) && (m_steps > m_steps_previous)) {
-            int avg_heartrate = 0;
-            if (!m_heartrate_samples.isEmpty()) {
-                for (int value : m_heartrate_samples) {
-                    avg_heartrate += value;
-                }
-                avg_heartrate = avg_heartrate / m_heartrate_samples.size();
-
-            }
-            emit samplesReady(m_lastSync, m_kind, m_intensity, m_steps - m_steps_previous, avg_heartrate);
+            steps_diff = m_steps - m_steps_previous;
         }
-        m_kind = 0;
-        m_intensity = 0;
-        m_steps_previous = m_steps;
-        m_steps = 0;
-        m_heartrate_samples.clear();
-        m_lastSync = now;
+        int avg_heartrate = 0;
+        if (!m_heartrate_samples.isEmpty()) {
+            for (int value : m_heartrate_samples) {
+                avg_heartrate += value;
+            }
+            avg_heartrate = avg_heartrate / m_heartrate_samples.size();
+        }
+
+        if ((m_intensity != 0) || (steps_diff != 0) || (avg_heartrate != 0)) {
+            emit samplesReady(m_lastSync, m_kind, m_intensity, steps_diff, avg_heartrate);
+        }
     }
+
+    // prepare for new data
+    m_kind = 0;
+    m_intensity = 0;
+    m_steps_previous = m_steps;
+    m_steps = 0;
+    m_heartrate_samples.clear();
+    m_lastSync = now;
+
 }
 
 void RealtimeActivitySample::slot_informationChanged(AbstractDevice::Info infokey, const QString &infovalue) {

--- a/daemon/src/realtimeactivitysample.h
+++ b/daemon/src/realtimeactivitysample.h
@@ -1,0 +1,39 @@
+#ifndef REALTIME_ACTIVITY_SAMPLE__H
+#define REALTIME_ACTIVITY_SAMPLE__H
+
+#include <QObject>
+#include <QDateTime>
+#include "abstractdevice.h"
+
+class RealtimeActivitySample : public QObject {
+    Q_OBJECT
+
+    public:
+        RealtimeActivitySample(QObject* parent = NULL);
+
+        void setKind(int _kind);
+        void setIntensity(int _intensity);
+        void setSteps(int _steps);
+        void setHeartrate(int _heartrate);
+
+    signals:
+        void samplesReady(QDateTime dt, int kind, int intensity, int steps, int heart);
+
+    public slots:
+    Q_SLOT void slot_informationChanged(AbstractDevice::Info infokey, const QString &infovalue);
+
+
+    private:
+        int m_kind = 0;
+        int m_intensity = 0;
+        int m_steps = 0;
+        int m_steps_previous = 0;
+        QList<int> m_heartrate_samples;
+
+        QDateTime m_lastSync;
+        qint64 m_interval = 60;
+
+        void sampleUpdated();
+};
+
+#endif //  REALTIME_ACTIVITY_SAMPLE__H


### PR DESCRIPTION
Until Infinitime implements physical activity monitor service (see https://github.com/InfiniTimeOrg/InfiniTime/issues/749) or similar mechanism to store and transfer sampled activity we can use only real time data from heart rate monitor and from motion service .

Closes https://github.com/piggz/harbour-amazfish/issues/274