### PR TITLE
PinetimeJFDevice::information returning empty string

### DIFF
--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -353,11 +353,13 @@ QString PinetimeJFDevice::information(Info i) const
 {
     DeviceInfoService *info = qobject_cast<DeviceInfoService*>(service(DeviceInfoService::UUID_SERVICE_DEVICEINFO));
     if (!info) {
+        qWarning() << "Device info service doesn't exists";
         return QString();
     }
 
-    InfiniTimeMotionService *motion = qobject_cast<InfiniTimeMotionService*>(service(InfiniTimeMotionService::UUID_CHARACTERISTIC_MOTION_STEPS));
+    InfiniTimeMotionService *motion = qobject_cast<InfiniTimeMotionService*>(service(InfiniTimeMotionService::UUID_SERVICE_MOTION));
     if (!motion) {
+        qWarning() << "Motion service doesn't exists";
         return QString();
     }
 


### PR DESCRIPTION
The service() function expects service uuid instead of characteristics uuid. As a consequence the information() function returns empty QString() instead of expected value. The function is called in Component.onCompleted of StepsPage, this sets _InfoSteps to "" and user can see 0 on the FirstPage

Steps to reproduce:
- open application, there is non-zero number of the FirstPage
- go to StepsPage and back
- Number of steps should be non-zero number