### PR TITLE
Bluetooth scan should have also icon otherwise is not visible

### DIFF
--- a/ui/qml/components/platform.uuitk/StylerPL.qml
+++ b/ui/qml/components/platform.uuitk/StylerPL.qml
@@ -62,6 +62,7 @@ QtObject {
     property string iconBattery: "image://theme/battery-good-symbolic"
     property string iconSteps: "../../pics/custom-icons/icon-m-steps2.png"
     property string iconHeartrate: "../../pics/custom-icons/icon-m-heartrate2.png"
+    property string iconDeviceScan: "image://theme/toolkit_input-search"
 
 
     property string iconStravaLogin: "image://theme/user-admin"

--- a/ui/qml/pages/PairPage.qml
+++ b/ui/qml/pages/PairPage.qml
@@ -150,6 +150,7 @@ PageListPL {
 
         PageMenuItemPL {
             enabled: !DaemonInterfaceInstance.pairing
+            iconSource: adapter && adapter.discovering ? "" : (styler.iconDeviceScan !== undefined ? styler.iconDeviceScan : "")
             text: adapter && adapter.discovering
                   ? qsTr("Stop scanning")
                   : qsTr("Scan for devices")


### PR DESCRIPTION
The explanation is the same as https://github.com/piggz/harbour-amazfish/pull/295 Single item menus are collapsed directly into button. The text description is not used. The button is not visible when haven't the icon.

I haven't realized that "scan button" is affected also because the second menu item is visible conditionally. 