### PR TITLE
Show message when bluetooth is off

### DIFF
--- a/ui/qml/pages/PairPage.qml
+++ b/ui/qml/pages/PairPage.qml
@@ -21,7 +21,11 @@ PageListPL {
     property QtObject _bluetoothManager : BluezQt.Manager
 
     function startDiscovery() {
-        if (!adapter || adapter.discovering) {
+        if (!adapter) {
+            showMessage(qsTr("Bluetooth adapter is not available"))
+            return
+        }
+        if (adapter.discovering) {
             return
         }
         adapter.startDiscovery()


### PR DESCRIPTION
The bluetoothManager.usableAdapter is null when the bluetooth is turned off. This patch popups dialog with error message when the discovery is triggered and bluetooth adapter is not available.

Closes #131