### PR TITLE
update documentation for sfos

### DIFF
--- a/documentation/build-instructions.md
+++ b/documentation/build-instructions.md
@@ -22,7 +22,7 @@ In the .pro file, you can set `FLAVOR = silica` (or `FLAVOR = $$FLAVOR` and in t
 To install missing packages, as pointed out by build errors, use:
 
 ```
-sb2 -R zypper in kcoreaddons-devel kdb-devel libKDb3-3 mkcal-qt5-devel libicu-devel
+sb2 -R zypper in mpris-qt5-devel libkf5archive-devel kcoreaddons-devel kdb-devel libKDb3-3 mkcal-qt5-devel libicu-devel pulseaudio-devel
 ```
 
 etc as pointed out by build errors.


### PR DESCRIPTION
I can see, that pulseaudio-devel wasn't added into documentation. 