### PR TITLE
Use native component for TimePicker

### DIFF
--- a/ui/qml/components/platform.uuitk/TimePickerDialogPL.qml
+++ b/ui/qml/components/platform.uuitk/TimePickerDialogPL.qml
@@ -1,1 +1,43 @@
-../platform.qtcontrols/TimePickerDialogPL.qml
+/* -*- coding: utf-8-unix -*-
+ *
+ * Copyright (C) 2019 Rinigus, 2019 Purism SPC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
+import "."
+
+DialogPL {
+    id: dialog
+
+    property alias time: datePicker.date
+
+    Item {
+        height: childrenRect.height
+        width: parent.width
+
+        DatePicker {
+            id: datePicker
+            anchors.horizontalCenter: parent.horizontalCenter
+            mode: "Hours|Minutes"
+            width: Math.min(parent.width - 2*styler.themeHorizontalPageMargin, implicitWidth)
+        }
+
+    }
+
+}


### PR DESCRIPTION
Ubuntu touch provides native date picker which can be used for time:
https://ubports.gitlab.io/docs/api-docs/lomiriuserinterfacetoolkit/qml-lomiri-components-pickers-datepicker.html

```
import Lomiri.Components.Pickers 1.0
DatePicker {
   mode: "Hours|Minutes"
}
```

In the end it looks like this:
![Screenshot_ubuntu20 04_2024-01-14_15:34:50](https://github.com/piggz/harbour-amazfish/assets/6171637/93a84001-bfcc-4646-bd03-ff7665e13ed0)
![Screenshot_ubuntu20 04_2024-01-14_15:34:09](https://github.com/piggz/harbour-amazfish/assets/6171637/3b31ee6c-4749-4449-8808-7f0f05549221)
