### PR TITLE
Only category CustomHuami should have icon in header

### DIFF
--- a/daemon/src/services/alertnotificationservice.cpp
+++ b/daemon/src/services/alertnotificationservice.cpp
@@ -30,7 +30,9 @@ void AlertNotificationService::sendAlert(const QString &sender, const QString &s
 
     QByteArray send = QByteArray(1, category) + QByteArray(1, 1); //1 alert
 
-    send += QByteArray(1, mapSenderToIcon(sender));
+    if (category == 0xfa) {
+        send += QByteArray(1, icon);
+    }
     send += sender.left(32).toUtf8() + QByteArray(1, m_seperatorChar); //Bip needs 0x00 for seperator, others may be different
 
     if (!subject.isEmpty()) {


### PR DESCRIPTION
The implementation in GadgetBridge sends icon only when the 
```
        if (alert.getCategory() == AlertCategory.CustomHuami) {
```

See https://github.com/Freeyourgadget/Gadgetbridge/blob/275deb4d06de6b64c0d7e73d13f6f2ad2879fe25/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/btle/profiles/alertnotification/AlertNotificationProfile.java#L106

The same issue was basically with Phone Calls https://github.com/piggz/harbour-amazfish/pull/286, which contain category IncomingCall, so icon byte is not expected.

Additionally, mapSenderToIcon() was triggered twice even icon variable already contain the result.
