### PR TITLE
Banglejs : Improvement over notifications

### DIFF
--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -51,9 +51,30 @@ void BangleJSDevice::sendAlert(const QString &sender, const QString &subject, co
         return;
     }
 
+    //For mails, there is a double notification which is empty except for sender
+    if(message.isEmpty() && subject.isEmpty())
+    {
+        return;
+    }
+
+    //This should provide a unique identifier and thread safe, which stays in an js int for now
+    class IdentifierGenerator
+    {
+    public :
+        qint64 getNewId() const
+        {
+            static qint64 id = QDateTime::currentMSecsSinceEpoch();
+            QMutexLocker locker(&mutex);
+            return id++;
+        }
+    private:
+        mutable QMutex mutex;
+
+    };
+
     QJsonObject o;
     o.insert("t", "notify");
-    o.insert("id", "");
+    o.insert("id", QString::number(IdentifierGenerator().getNewId())); //id is necessary for some apps like messageui, and should be unique
     o.insert("src", "");
     o.insert("title", "");
     o.insert("subject", subject);

--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -74,7 +74,7 @@ void BangleJSDevice::incomingCall(const QString &caller)
 
     QJsonObject o;
     o.insert("t", "call");
-    o.insert("cmd", "accept");
+    o.insert("cmd", "incoming");
     o.insert("name", caller);
     o.insert("number", "");
     uart->txJson(o);


### PR DESCRIPTION
1. Incoming calls

From specifications of notifications of gadgetbridge (https://www.espruino.com/Gadgetbridge), cmd can be 
t:"call", cmd:"accept/incoming/outgoing/reject/start/end", name: "name", number: "+491234" - call

example shows :
GB({"t":"call","cmd":"incoming","name":"name","number":"+441234123123"})

Tried this way and incoming calls show on my bangle.js 2
I didn't check however how to accept or refuse calls...

2. Notifications (sendAlert)

Put an unique identifier.
Also, filter out messages which have an empty body and subject. Not convinced 100%, but something similar is done for instance for MiBandService::sendAlert
For me, it concerns mails which sends two notifications, the second with "courriel" (so in French) in the sender field, with empty subject and message.

I suppose it would be better to filter out those based on the event, but I do not master this part of code.