### PR TITLE
Pop after timer refresh daemon

### DIFF
--- a/ui/qml/pages/Settings-alarms.qml
+++ b/ui/qml/pages/Settings-alarms.qml
@@ -57,7 +57,6 @@ PagePL {
             text: qsTr("Save Settings")
             onClicked: {
                 saveSettings();
-                app.pages.pop();
             }
         }
 
@@ -69,6 +68,7 @@ PagePL {
             running: false
             onTriggered: {
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_ALARMS);
+                app.pages.pop();
             }
         }
     }

--- a/ui/qml/pages/Settings-device.qml
+++ b/ui/qml/pages/Settings-device.qml
@@ -106,7 +106,6 @@ PagePL {
                 text: qsTr("Save Settings")
                 onClicked: {
                     saveSettings();
-                    app.pages.pop();
                 }
             }
         }
@@ -122,6 +121,7 @@ PagePL {
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_DEVICE_TIME);
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_DEVICE_UNIT);
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_DISCONNECT_NOTIFICATION);
+                app.pages.pop();
             }
         }
     }

--- a/ui/qml/pages/Settings-huami-shortcuts.qml
+++ b/ui/qml/pages/Settings-huami-shortcuts.qml
@@ -58,7 +58,6 @@ PagePL {
             onClicked: {
                 saveDisplayItems();
                 saveSettings();
-                app.pages.pop();
             }
         }
 
@@ -70,6 +69,7 @@ PagePL {
             running: false
             onTriggered: {
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_DEVICE_DISPLAY_ITEMS);
+                app.pages.pop();
             }
         }
     }

--- a/ui/qml/pages/Settings-profile.qml
+++ b/ui/qml/pages/Settings-profile.qml
@@ -209,7 +209,6 @@ PagePL {
             text: qsTr("Save Profile")
             onClicked: {
                 saveProfile();
-                app.pages.pop();
             }
         }
         Timer {
@@ -225,6 +224,7 @@ PagePL {
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_USER_DISPLAY_ON_LIFT);
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_USER_ALL_DAY_HRM);
                 DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_USER_HRM_SLEEP_DETECTION)
+                app.pages.pop();
             }
         }
     }


### PR DESCRIPTION
Fixes #339 

It seems app.pages.pop() calls destructor of the Page including Timer before it is triggered