### PR TITLE
Alarm doesn't store TimePicker value

### DIFF
--- a/ui/qml/components/platform.uuitk/TimePickerDialogPL.qml
+++ b/ui/qml/components/platform.uuitk/TimePickerDialogPL.qml
@@ -26,6 +26,8 @@ DialogPL {
     id: dialog
 
     property alias time: datePicker.date
+    property alias hour: datePicker.hours
+    property alias minute: datePicker.minutes
 
     Item {
         height: childrenRect.height


### PR DESCRIPTION
I have noticed, that TimePicker sets time property, but Alarm is using hour and minute. The lomiri DatePicker provides read/only hours and minutes properties. I am not sure if is needed to provide hour and minute as read/write property. It seems Alarm doesn't need that. 

There is another use in ui/qml/pages/Settings-profile.qml, but I don't have time to investigate it now. I may get to this later, but would rather not promise anything.

https://ubports.gitlab.io/docs/api-docs/lomiriuserinterfacetoolkit/qml-lomiri-components-pickers-datepicker.html

