### PR TITLE
AmazfitNeo notification is using AlertNotificationService

### DIFF
--- a/daemon/src/devices/huamidevice.h
+++ b/daemon/src/devices/huamidevice.h
@@ -27,7 +27,7 @@ public:
 
     void applyDeviceSetting(Settings s) override;
 
-    void sendAlert(const QString &sender, const QString &subject, const QString &message) override;
+    virtual void sendAlert(const QString &sender, const QString &subject, const QString &message) override;
     void incomingCall(const QString &caller) override;
 
     QString softwareRevision();

--- a/daemon/src/devices/neodevice.cpp
+++ b/daemon/src/devices/neodevice.cpp
@@ -28,10 +28,15 @@ int NeoDevice::supportedFeatures() const
 
 void NeoDevice::sendAlert(const QString &sender, const QString &subject, const QString &message)
 {
-    MiBandService *mi = qobject_cast<MiBandService*>(service(MiBandService::UUID_SERVICE_MIBAND));
-    if (mi) {
-        mi->sendAlert(sender, subject, message);
+
+    AlertNotificationService *alert = qobject_cast<AlertNotificationService*>(service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION));
+
+    qDebug() << Q_FUNC_INFO << alert;
+
+    if (alert) {
+        alert->sendAlert(sender.left(10), subject.left(6), "");
     }
+
 }
 
 void NeoDevice::serviceEvent(uint8_t event)


### PR DESCRIPTION
it seems that max length of message is limited.
The specification says 18 characters. The screen shows only "+1" or "+2" anyway.

Code worked for me, but it would be great if @kirbylife can look at it as well.