### PR TITLE
Add missing pics into qrc

### DIFF
--- a/ui/amazfish.qrc
+++ b/ui/amazfish.qrc
@@ -79,13 +79,17 @@
         <file>qml/pics/devices/amazfit-bip.png</file>
         <file>qml/pics/devices/amazfit-bips.png</file>
         <file>qml/pics/devices/amazfit-cor.png</file>
+        <file>qml/pics/devices/amazfit-gtr2.png</file>
         <file>qml/pics/devices/amazfit-gtr.png</file>
+        <file>qml/pics/devices/amazfit-gts2.png</file>
         <file>qml/pics/devices/amazfit-gts.png</file>
+        <file>qml/pics/devices/amazfit-neo.png</file>
+        <file>qml/pics/devices/asteroidos.png</file>
+        <file>qml/pics/devices/banglejs.png</file>
         <file>qml/pics/devices/miband2.png</file>
         <file>qml/pics/devices/miband3.png</file>
         <file>qml/pics/devices/miband4.png</file>
         <file>qml/pics/devices/pinetime.png</file>
-        <file>qml/pics/devices/banglejs.png</file>
         <file>qml/pics/map_btn_center.png</file>
         <file>qml/pics/map_btn_max.png</file>
         <file>qml/pics/map_btn_min.png</file>


### PR DESCRIPTION
I have spotted that some pictures are not shown in `FLAVOR=qtcontrols`.

In logs I can see following message:
```
qrc:/qml/components/DeviceButton.qml:14:5: QML Image: Cannot open: qrc:/qml/pics/devices/asteroidos.png
```

I have updated all files in directory as follows:
```
for i in $(ls -1|sort); do echo "        <file>qml/pics/devices/$i</file>"; done
```