### PR TITLE
Add appdata.xml

### DIFF
--- a/ui/harbour-amazfish-ui.appdata.xml
+++ b/ui/harbour-amazfish-ui.appdata.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <name>Amazfish</name>
+  <summary>Smart watch sync app</summary>
+  <id>uk.co.piggz.amazfish</id>
+  <launchable type="desktop-id">harbour-amazfish-ui.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <description>
+    <p>
+        Companion application for Huami Devices (such as Amazfit Bip, Cor, MiBand2/3 and GTS and GTS) and the Pinetime Infinitime.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/piggz/harbour-amazfish</url>
+  <url type="bugtracker">https://github.com/piggz/harbour-amazfish/issues</url>
+  <url type="donation">https://paypal.me/piggz</url>
+  <requires>
+    <display_length compare="ge">small</display_length>
+  </requires>
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </recommends>
+  <developer id="@piggz@fosstodon.org">
+    <name>Adam Pigg</name>
+  </developer>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/piggz/harbour-amazfish/raw/2.2.4/screenshots/screenshot1.png</image>
+      <caption/>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/piggz/harbour-amazfish/raw/2.2.4/screenshots/screenshot2.png</image>
+      <caption/>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/piggz/harbour-amazfish/raw/2.2.4/screenshots/screenshot3.png</image>
+      <caption/>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Sports</category>
+    <category>Utility</category>
+  </categories>
+  <keywords>
+    <keyword>Smartwatch</keyword>
+    <keyword>Bluetooth</keyword>
+    <keyword>Amazfit Bip</keyword>
+    <keyword>Amazfit GTS</keyword>
+    <keyword>Amazfit GTR2</keyword>
+    <keyword>Pinetime InfiniTime</keyword>
+    <keyword>Bangle.js</keyword>
+    <keyword>AsteroidOS</keyword>
+  </keywords>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="2.2.4" timestamp="1709471020">
+      <description>
+        <p>Fix schedule display on lift wrist</p>
+        <p>Misc Ubuntu Touch fixes</p>
+        <p>Fix alert icon handling</p>
+        <p>AsteroidOS Screenshot support</p>
+        <p>Fix setting-save bug</p>
+        <p>Thanks to @jmlich and @nephros</p>
+      </description>
+    </release>
+    <release version="2.2.0" timestamp="1704114220">
+      <description>
+        <p>Implement Scheduled Display on Lift Wrist</p>
+        <p>Implement find-my-phone feature</p>
+        <p>Add file download for Amazfit GTR</p>
+        <p>Support watchfaces for GTS2/GTR2</p>
+        <p>Support new weather service on Pinetime</p>
+        <p>Pinetime steps logging</p>
+        <p>Log battery level</p>
+        <p>Support phone calls on Ubuntu Touch (UT)</p>
+        <p>UT UI fixes</p>
+        <p>Weather fixes</p>
+        <p>Fix for messages that contain Emoji chcaracters</p>
+        <p>Thanks to Jozef Mlich for the Pinetime, UBPortsand weather updates</p>
+      </description>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
As is mentioned in https://github.com/flathub/flathub/pull/5173 the appdata.xml should be part of main repository. 

The gnome-software listing and flathub listing (which I am not able to preview) is build from that file

![image](https://github.com/piggz/harbour-amazfish/assets/6171637/90270929-1741-47fe-9a24-6b6ac75334cc)

There is Changelog section which should be updated with new release.

It is possible to validate file using following command
```
appstream-util validate harbour-amazfish-ui.appdata.xml
```
The flatpak provides yet another validator tool which provides valuable information. I have adjusted changelog first letters to upper case according to its output.  
```
flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream harbour-amazfish-ui.appdata.xml
```