### PR TITLE
Add BatteryPage to qrc

### DIFF
--- a/ui/amazfish.qrc
+++ b/ui/amazfish.qrc
@@ -71,6 +71,7 @@
         <file>qml/pages/Settings-profile.qml</file>
         <file>qml/pages/SleepPage.qml</file>
         <file>qml/pages/SportPage.qml</file>
+        <file>qml/pages/BatteryPage.qml</file>
         <file>qml/pages/SportsSummaryPage.qml</file>
         <file>qml/pages/StravaSettingsPage.qml</file>
         <file>qml/pages/StravaUploadPage.qml</file>


### PR DESCRIPTION
Similar to https://github.com/piggz/harbour-amazfish/pull/359
qtcontrols flavor requires everything in qrc. This could be solved probably by some script in future. 