### PR TITLE
Show window icon for Kirigami

### DIFF
--- a/ui/amazfish.qrc
+++ b/ui/amazfish.qrc
@@ -123,5 +123,6 @@
         <file>qml/harbour-amazfish.qml</file>
         <file>qml/components/TruncationModes.qml</file>
         <file>qml/components/DateNavigation.qml</file>
+        <file>icons/172x172/harbour-amazfish-ui.png</file>
     </qresource>
 </RCC>

--- a/ui/src/harbour-amazfish-ui.cpp
+++ b/ui/src/harbour-amazfish-ui.cpp
@@ -10,6 +10,7 @@
 #include <sailfishapp.h>
 #else
 #include <QQmlApplicationEngine>
+#include <QQuickWindow>
 #endif
 
 #include <QTranslator>
@@ -129,8 +130,12 @@ int main(int argc, char *argv[])
     view->load("./share/harbour-amazfish-ui/qml/harbour-amazfish.qml");
 #else
     view->load(QUrl("qrc:/qml/harbour-amazfish.qml"));
-#endif
 
+    if (QQuickWindow* window = qobject_cast<QQuickWindow*>(view->rootObjects().at(0))) {
+        window->setIcon(QIcon(":/icons/172x172/harbour-amazfish-ui.png"));
+    }
+
+#endif
 
     return app->exec();
 }


### PR DESCRIPTION
Previously, there were generic icon visible in windowed mode.
I am not sure if is needed to set icon also for Sailfish or Ubuntu Touch. Ubuntu Touch have windowed mode, but I don't have device to test it. For sure it is necessary to set right file path for each of them. 

![image](https://github.com/piggz/harbour-amazfish/assets/6171637/44ab4071-d4f1-45c1-b98e-3264a54a1f0e)
