### PR TITLE
[kirigami] DatePicker dialog doesn't pop() when accepted

### DIFF
--- a/ui/qml/components/platform.kirigami/DialogPL.qml
+++ b/ui/qml/components/platform.kirigami/DialogPL.qml
@@ -38,9 +38,9 @@ PagePL {
             if (acceptDestinationPop)
                 app.pages.pop(acceptDestination);
             else
-                app.push(acceptDestination);
-        } //else
-            //app.pages.pop();
+                app.pages.push(acceptDestination);
+        } else
+            app.pages.pop();
     }
 
     function accept() {

--- a/ui/qml/components/platform.qtcontrols/DialogPL.qml
+++ b/ui/qml/components/platform.qtcontrols/DialogPL.qml
@@ -41,7 +41,7 @@ PagePL {
             if (acceptDestinationPop)
                 app.pages.pop(acceptDestination);
             else
-                app.push(acceptDestination);
+                app.pages.push(acceptDestination);
         } else
             app.pages.pop();
     }

--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -11,21 +11,18 @@ PagePL {
 
     function unpairAccepted() {
         DaemonInterfaceInstance.disconnect();
-        app.pages.push(Qt.resolvedUrl("./PairSelectDeviceType.qml"));
     }
 
     pageMenu: PageMenuPL {
         PageMenuItemPL {
             text: qsTr("Pair with watch")
             onClicked: {
-                var page = AmazfishConfig.pairedAddress
-                        ? "UnpairDeviceDialog.qml"
-                        : "PairSelectDeviceType.qml"
-
-                var obj = app.pages.push(Qt.resolvedUrl(page));
-
                 if (AmazfishConfig.pairedAddress) {
+                    var obj = app.pages.push(Qt.resolvedUrl("UnpairDeviceDialog.qml"));
+                    obj.acceptDestination = Qt.resolvedUrl("PairSelectDeviceType.qml")
                     obj.accepted.connect(unpairAccepted);
+                } else {
+                    app.pages.push(Qt.resolvedUrl("PairSelectDeviceType.qml"));
                 }
             }
         }


### PR DESCRIPTION
In c48f79b96e6e81e2e01f60a0c36ec7706d6887b6 there was a fix of Dialog behaviour for Device Unpair operation. This broke DatePicker Dialog (User Settings -> Birthday) .

In this fix is used acceptDestination variable show the Unpair works with previous implementation and DatePicker works as well.

Same issue applies to TimePicker Dialog as well.

The change may affect also unpair page