### PR TITLE
typo in appdata xml

### DIFF
--- a/ui/harbour-amazfish-ui.appdata.xml
+++ b/ui/harbour-amazfish-ui.appdata.xml
@@ -59,7 +59,7 @@
       <description>
         <p>Fix for Sailfish 4.6</p>
         <p>Infinitime HRM workaround</p>
-        <p>Implement immediate alert service for infinitime<p>
+        <p>Implement immediate alert service for infinitime</p>
         <p>Kirigam improvements</p>
         <p>Dont display battery info twice</p>
         <p>Battery page title</p>


### PR DESCRIPTION
Rebuild of flatpak reports following error:
```
$ flatpak-builder --verbose --user --install --force-clean build-dir uk.co.piggz.amazfish.json
...
Error: Error on line 68 char 21: Element “description” was closed, but the currently open element is “p”
...
```