### PR TITLE
Update SFOS SDK CI image to 4.6.0.13

### DIFF
--- a/.github/workflows/sailfishos.yml
+++ b/.github/workflows/sailfishos.yml
@@ -3,7 +3,7 @@ name: SailfishOS Build
 on: [push, pull_request]
 
 env:
-  OS_VERSION: 4.5.0.16
+  OS_VERSION: 4.6.0.13
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
             mkdir -p build ;
             cd build ;
             cp -r /share/* . ;
-            sb2 -t SailfishOS-$OS_VERSION-${{ matrix.arch }} -R zypper --non-interactive ar --no-gpgcheck http://repo.merproject.org/obs/home:/piggz:/kf5/sailfish_latest_${{ matrix.arch }}/ piggz ;
+            sb2 -t SailfishOS-$OS_VERSION-${{ matrix.arch }} -R zypper --non-interactive ar --no-gpgcheck https://repo.sailfishos.org/obs/sailfishos:/chum/4.6_${{ matrix.arch }}/ sailfishos_chum ;
             sb2 -t SailfishOS-$OS_VERSION-${{ matrix.arch }} -R zypper --non-interactive refresh ;
             sb2 -t SailfishOS-$OS_VERSION-${{ matrix.arch }} -R zypper --non-interactive in -y mpris-qt5-devel libkf5archive-devel kcoreaddons-devel kdb-devel libKDb3-3 mkcal-qt5-devel libicu-devel pulseaudio-devel;
             mb2 -t SailfishOS-$OS_VERSION-${{ matrix.arch }} build ;

--- a/documentation/build-instructions.md
+++ b/documentation/build-instructions.md
@@ -13,7 +13,7 @@ To get into the build machine (if started by Sailfish IDE)
 Use the `sb2-config` command to make your ARM target the default
 
 Add this repo which provides KF5 packages
-`sb2 -R zypper ar http://repo.merproject.org/obs/home:/piggz:/kf5/sailfish_latest_aarch64/ piggz`
+`sb2 -R zypper ar https://repo.sailfishos.org/obs/sailfishos:/chum/4.6_aarch64/ sailfishos_chum`
 and
 `sb2 -R zypper refresh`
 


### PR DESCRIPTION
SDK docker image was updated 
https://github.com/CODeRUS/docker-sailfishos-platform-sdk/issues/10

Currently, it seems repository https://repo.sailfishos.org/obs/home:/piggz:/kf5/ doesn't work so I have replaced it with chum repo https://repo.sailfishos.org/obs/sailfishos:/chum/4.6_i486/