### PR TITLE
Add missing mapbox components for Ubuntu Touch

### DIFF
--- a/click/disable-armhf-version-check.patch
+++ b/click/disable-armhf-version-check.patch
@@ -1,0 +1,14 @@
+diff --git a/platform/qt/qt.cmake b/platform/qt/qt.cmake
+index cb11d5352..1e7411df3 100644
+--- a/platform/qt/qt.cmake
++++ b/platform/qt/qt.cmake
+@@ -226,7 +226,8 @@ configure_package_config_file(
+
+ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QMapLibreGLConfigVersion.cmake
+     VERSION ${MBGL_QT_VERSION}
+-    COMPATIBILITY AnyNewerVersion)
++    COMPATIBILITY AnyNewerVersion
++    ARCH_INDEPENDENT)
+
+ install(EXPORT QMapLibreGLTargets
+     DESTINATION ${CMAKECONFIG_INSTALL_DIR}

--- a/click/enable-clang-cross-compiling.patch
+++ b/click/enable-clang-cross-compiling.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 71db29e2f..69ca6d4bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,27 @@ set(
+     "--leak-check=full --gen-suppressions=all --error-exitcode=1 --suppressions=${PROJECT_SOURCE_DIR}/scripts/valgrind.sup"
+ )
+
++set(CROSS_COMPILING OFF)
++
++if($ENV{ARCH} STREQUAL "armhf")
++    set(CROSS_COMPILING ON)
++    set(CMAKE_SYSTEM_PROCESSOR arm)
++elseif($ENV{ARCH} STREQUAL "arm64")
++    set(CROSS_COMPILING ON)
++    set(CMAKE_SYSTEM_PROCESSOR aarch64)
++endif()
++
++if(CROSS_COMPILING)
++    set(CMAKE_SYSTEM_NAME Linux)
++
++    set(CMAKE_PREFIX_PATH /usr/lib/$ENV{ARCH_TRIPLET};/usr/lib/$ENV{ARCH_TRIPLET}/cmake)
++    set(CMAKE_C_COMPILER_TARGET $ENV{ARCH_TRIPLET})
++    set(CMAKE_CXX_COMPILER_TARGET $ENV{ARCH_TRIPLET})
++
++    set(ICU_INCLUDE_DIR /usr/include/$ENV{ARCH_TRIPLET})
++    find_package(ICU REQUIRED COMPONENTS uc)
++endif()
++
+ include(CTest)
+
+ if(NOT CMAKE_BUILD_TYPE)

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -43,8 +43,11 @@ libraries:
     src_dir: 3rdparty/maplibre-gl-native
     prebuild:
     - mkdir -p ${ROOT}/3rdparty
-    - git -C ${SRC_DIR} pull || git clone -b qt-v2.0.1 --recursive --shallow-submodules --depth 1 https://github.com/maplibre/maplibre-gl-native.git ${SRC_DIR}
-    - git apply --directory ${SRC_DIR} ${ROOT}/click/fix-compilation-with-clickable.patch || /bin/true
+    - rm -rf ${ROOT}/3rdparty/maplibre-gl-native
+    - git clone -b qt-v2.0.1 --recursive --shallow-submodules --depth 1 https://github.com/maplibre/maplibre-gl-native.git ${SRC_DIR}
+    - cd ${ROOT}/3rdparty/maplibre-gl-native && git apply --verbose ${ROOT}/click/disable-armhf-version-check.patch
+    - cd ${ROOT}/3rdparty/maplibre-gl-native && git apply --verbose ${ROOT}/click/enable-clang-cross-compiling.patch
+    - cd ${ROOT}/3rdparty/maplibre-gl-native && git apply --verbose ${ROOT}/click/fix-compilation-with-clickable.patch
     builder: cmake
     build_args:
     - -DMBGL_WITH_QT=ON
@@ -57,7 +60,8 @@ libraries:
     src_dir: 3rdparty/mapbox-gl-qml
     prebuild:
     - mkdir -p ${ROOT}/3rdparty
-    - git -C ${SRC_DIR} pull || git clone -b 2.1.1 --recursive --shallow-submodules --depth 1 https://github.com/rinigus/mapbox-gl-qml.git ${SRC_DIR}
+    - rm -rf ${ROOT}/3rdparty/mapbox-gl-qml
+    - git clone -b 2.1.1 --recursive --shallow-submodules --depth 1  https://github.com/rinigus/mapbox-gl-qml.git ${SRC_DIR}
     builder: cmake
     build_args:
     - -DCMAKE_CXX_STANDARD=14


### PR DESCRIPTION
It finally works! Currently it looks like this:


![screenshot20240811_115801379](https://github.com/user-attachments/assets/23453bb3-c81a-408b-b03a-75a463451ce4)
