### PR TITLE
CI: fix deprecated actions/upload-artifact@v2

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -44,7 +44,7 @@ jobs:
         flatpak build-bundle ${{ github.workspace }}/repo ${{ github.workspace }}/uk.co.piggz.amazfish.flatpak uk.co.piggz.amazfish
 
     - name: Upload Flatpak
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: uk.co.piggz.amazfish.flatpak
+        pattern: uk.co.piggz.amazfish.flatpak
         path: uk.co.piggz.amazfish.flatpak


### PR DESCRIPTION
See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Fixes this issue https://github.com/piggz/harbour-amazfish/actions/runs/10757653199/job/29831944241