### PR TITLE
Selection of adapter in Application Settings doesn't work 

### DIFF
--- a/ui/qml/pages/Settings-app.qml
+++ b/ui/qml/pages/Settings-app.qml
@@ -27,7 +27,12 @@ PagePL {
             textRole: "path"
             label: qsTr("BT Adapter")
             Component.onCompleted: {
-                cboLocalAdapter.value =  AmazfishConfig.localAdapter;
+                for (var i = 0; i < adapters.rowCount(); i++) {
+                    if (adapters.get(i).path == AmazfishConfig.localAdapter) {
+                        cboLocalAdapter.currentIndex = i;
+                        return
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
It seems the cboLocalAdapter.value is read only
```
[20240920 10:25:57.635 CEST W] qrc:/qml/pages/Settings-app.qml:30 - qrc:/qml/pages/Settings-app.qml:30: TypeError: Cannot assign to read-only property "value"
```

It seems other ComboBoxPL objects are using currentIndex instead of value (which is alias to ComboBox.currentText).

I wasn't able to use .index(),.data(), and roles, so I have added .get() method into AdapterModel into https://github.com/piggz/qble/pull/2

