### PR TITLE
add missing left margins to icons

### DIFF
--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -94,9 +94,8 @@ PagePL {
                 anchors.rightMargin: 2
                 height: parent.height - 4
             }
-
-
         }
+
         RowLayout {
             height: styler.themeItemSizeSmall
             width: parent.width
@@ -149,7 +148,6 @@ PagePL {
             }
         }
 
-
         SectionHeaderPL {
             text: qsTr("Steps")
             visible: supportsFeature(Amazfish.FEATURE_STEPS)
@@ -158,6 +156,8 @@ PagePL {
         // steps
         IconPL {
             id: imgSteps
+            anchors.left: parent.left
+            anchors.leftMargin: styler.themePaddingLarge
             iconName: styler.iconSteps
             height: styler.themeIconSizeMedium
             width: height
@@ -208,6 +208,10 @@ PagePL {
 
         //Heartrate
         RowLayout {
+            anchors.left: parent.left
+            anchors.leftMargin: styler.themePaddingLarge
+            anchors.right: parent.right
+            anchors.rightMargin: styler.themePaddingLarge
             spacing: styler.themePaddingLarge
             width: parent.width
             visible: supportsFeature(Amazfish.FEATURE_HRM)
@@ -270,8 +274,6 @@ PagePL {
                 }
             }
         }
-
-
     }
 
     onPageStatusActive: {

--- a/ui/qml/pages/SportPage.qml
+++ b/ui/qml/pages/SportPage.qml
@@ -61,6 +61,8 @@ PagePL {
                 Layout.rowSpan: 3
                 Layout.preferredWidth: styler.themeItemSizeLarge
                 Layout.preferredHeight: styler.themeItemSizeLarge
+                Layout.alignment: Qt.AlignLeft
+                Layout.leftMargin: styler.themePaddingLarge
                 iconName: styler.customIconPrefix + "icon-m-" + getKindString(kindstring) + styler.customIconSuffix
             }
 


### PR DESCRIPTION
Some of the icons on the main screen and in sports page are missing a left margin. This PR does add margins.

Before:

![grafik](https://github.com/user-attachments/assets/914c7c36-82c9-4dd7-a2c7-747895ebea88)

![grafik](https://github.com/user-attachments/assets/f71ad894-60a1-490a-93d8-60e363773f45)

After:

![grafik](https://github.com/user-attachments/assets/eb6958b0-cae1-4361-a4e3-f362fb335512)

![grafik](https://github.com/user-attachments/assets/2195a7df-f468-4b9f-9c3d-7a6961fcc993)
