### PR TITLE
Show BusyIndicator in kirigami (refactor _placeholderText)

### DIFF
--- a/ui/qml/components/platform.qtcontrols/BusyIndicatorPL.qml
+++ b/ui/qml/components/platform.qtcontrols/BusyIndicatorPL.qml
@@ -23,5 +23,7 @@ import QtQuick.Layouts 1.12
 BusyIndicator {
     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
 //    anchors.centerIn: parent
+    height: styler.themeFontSizeHuge
+    width: height
 }
 

--- a/ui/qml/components/platform.silica/PageListPL.qml
+++ b/ui/qml/components/platform.silica/PageListPL.qml
@@ -35,11 +35,19 @@ Page {
     property alias  pageMenu: menuLoader.sourceComponent
     property alias  placeholderEnabled: viewPlaceholder.enabled
     property alias  placeholderText: viewPlaceholder.hintText
+    property alias  background: backgroundLoader.sourceComponent
     property string title
 
     signal pageStatusActivating
     signal pageStatusActive
     signal pageStatusInactive
+
+
+    Loader {
+        id: backgroundLoader
+        active: sourceComponent ? true : false
+        anchors.centerIn: parent
+    }
 
     SilicaListView {
         id: listView

--- a/ui/qml/pages/PairPage.qml
+++ b/ui/qml/pages/PairPage.qml
@@ -10,12 +10,13 @@ PageListPL {
     //backNavigation: !DaemonInterfaceInstance.pairing
     title: qsTr("Pair Device")
 
-    placeholderText: _placeholderText || qsTr("No devices found")
-    placeholderEnabled: devicesModel.rowCount() > 0
+    placeholderText: qsTr("No devices found")
+    placeholderEnabled: (delegateModel.count === 0) && !busy
+    property bool busy: (adapter && adapter.discovering && !page.count) || DaemonInterfaceInstance.connectionState == "pairing"
+    //busy: discoveryModel.running || DaemonInterfaceInstance.pairing
 
     property string deviceType
     property variant aliases
-    property string _placeholderText
     property string _deviceName
     property string _deviceAddress
     property QtObject adapter: _bluetoothManager ? _bluetoothManager.usableAdapter : null
@@ -156,7 +157,7 @@ PageListPL {
     }
 
     // Set to undefined when pairing to show busy indicator only
-    model: !DaemonInterfaceInstance.pairing && !_placeholderText
+    model: (DaemonInterfaceInstance !== undefined) && !DaemonInterfaceInstance.pairing && delegateModel.count > 0
            ? delegateModel
            : undefined
 
@@ -165,13 +166,12 @@ PageListPL {
         //busy: discoveryModel.running || DaemonInterfaceInstance.pairing
 
         PageMenuItemPL {
-            enabled: !DaemonInterfaceInstance.pairing
+            enabled: (DaemonInterfaceInstance !== undefined) && !DaemonInterfaceInstance.pairing
             iconSource: adapter && adapter.discovering ? "" : (styler.iconDeviceScan !== undefined ? styler.iconDeviceScan : "")
             text: adapter && adapter.discovering
                   ? qsTr("Stop scanning")
                   : qsTr("Scan for devices")
             onClicked: {
-                _placeholderText = ""
                 if (adapter && adapter.discovering) {
                     stopDiscovery();
                 } else {
@@ -191,10 +191,13 @@ PageListPL {
         }
     }
 
-    BusyIndicatorPL {
+    background: BusyIndicatorPL {
         id: busyIndicator
         anchors.centerIn: parent
-        running: (adapter && adapter.discovering && !page.count) || DaemonInterfaceInstance.connectionState == "pairing"
+        running: busy
     }
+
+
+
 }
 


### PR DESCRIPTION
I was trying to make some cleanup of PairingPage. I have found an issue with missing BusyIndicator https://github.com/piggz/harbour-amazfish/issues/406
This pull request intent is to demonstrate what change was done in order to make BusyIndicator visible in pairing page.