### PR TITLE
add total sleep time and reformat sleep times

### DIFF
--- a/ui/qml/pages/SleepPage.qml
+++ b/ui/qml/pages/SleepPage.qml
@@ -19,14 +19,23 @@ PagePL {
         width: parent.width
         anchors.top: parent.top
         anchors.margins: styler.themePaddingMedium
-        spacing: styler.themePaddingLarge
+        spacing: styler.themePaddingMedium
 
         LabelPL {
             id: lblSleepLastnight
-            font.pixelSize: styler.themeFontSizeExtraLarge * 3
+            font.pixelSize: styler.themeFontSizeExtraLarge * 2
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: qsTr("%1 hrs").arg(parseFloat(Math.round(graphSleepSummary.lastY * 100) / 100).toFixed(2))
+            text: qsTr("Total %1").arg(decimalToHourMin(graphSleepSummary.lastY + graphSleepSummary.lastZ))
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        LabelPL {
+            id: lblLightSleepLastnight
+            font.pixelSize: styler.themeFontSizeExtraLarge
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width
+            text: qsTr("Light %1").arg(decimalToHourMin(graphSleepSummary.lastY))
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -35,7 +44,7 @@ PagePL {
             font.pixelSize:styler.themeFontSizeExtraLarge
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: qsTr("Deep %1 hrs").arg(parseFloat(Math.round(graphSleepSummary.lastZ * 100) / 100).toFixed(2))
+            text: qsTr("Deep %1").arg(decimalToHourMin(graphSleepSummary.lastZ))
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -77,6 +86,12 @@ PagePL {
 
     function updateGraphs() {
         graphSleepSummary.updateGraph(day);
+    }
+
+    function decimalToHourMin(decHours) {
+        var timeDate = new Date(0,0);
+        timeDate.setMinutes(decHours * 60);
+        return timeDate.toLocaleTimeString([], {timeStyle: 'short'});
     }
 
     onPageStatusActive: {


### PR DESCRIPTION
I find it confusing to see the "light" sleep time in very large letters and the small deep sleep time and those not matching the total time on the graph. I think more interesting is the total time to answer the question "how long did I sleep".

This PR will add total sleep label, name light sleep text with "light" and format all times with the locale short format.

Before:

![grafik](https://github.com/user-attachments/assets/33ed503c-c7de-4f57-95fa-b88f3f8a02f8)

After:

![grafik](https://github.com/user-attachments/assets/fb488ae4-e23c-431e-9009-e77b329dcf96)
