### PR TITLE
SailfishOS: enable cover page

### DIFF
--- a/ui/qml/components/platform.kirigami/ApplicationWindowPL.qml
+++ b/ui/qml/components/platform.kirigami/ApplicationWindowPL.qml
@@ -35,7 +35,7 @@ Kirigami.ApplicationWindow {
     pageStack.globalToolBar.showNavigationButtons: pages && pages.currentIndex > 0 ?
                                                        Kirigami.ApplicationHeaderStyle.ShowBackButton :
                                                        Kirigami.ApplicationHeaderStyle.NoNavigationButtons
-
+    property var    cover
     property real   compassOrientationOffset: 0
     property bool   isConvergent: true
     property var    initialPage

--- a/ui/qml/components/platform.qtcontrols/ApplicationWindowPL.qml
+++ b/ui/qml/components/platform.qtcontrols/ApplicationWindowPL.qml
@@ -27,6 +27,7 @@ ApplicationWindow {
     height: 480
     visible: true
 
+    property var    cover
     property real   compassOrientationOffset: 0
     property alias  initialPage: pageStack.initialItem
     property string menuPageUrl

--- a/ui/qml/components/platform.uuitk/ApplicationWindowPL.qml
+++ b/ui/qml/components/platform.uuitk/ApplicationWindowPL.qml
@@ -28,6 +28,7 @@ ApplicationWindow {
     height: 480
     visible: true
 
+    property var    cover
     property real   compassOrientationOffset: 0
     property alias  initialPage: pageStack.initialItem
     property string menuPageUrl

--- a/ui/qml/cover/CoverPage.qml
+++ b/ui/qml/cover/CoverPage.qml
@@ -70,7 +70,7 @@ CoverBackground {
 
             Image {
                 id: imgSteps
-                source: "../pics/icon-m-steps.png"
+                source: "../pics/custom-icons/icon-m-steps.png"
                 height: Theme.iconSizeMedium
                 width: height
             }
@@ -94,7 +94,7 @@ CoverBackground {
 
             Image {
                 id: imgHeartrate
-                source: "../pics/icon-m-heartrate.png"
+                source: "../pics/custom-icons/icon-m-heartrate.png"
                 height: Theme.iconSizeMedium
                 width: height
             }

--- a/ui/qml/harbour-amazfish.qml
+++ b/ui/qml/harbour-amazfish.qml
@@ -13,7 +13,7 @@ ApplicationWindowPL
     id: app
     initialPage: Component { FirstPage { } }
     property var    rootPage: null
-    //cover: Qt.resolvedUrl("cover/CoverPage.qml")
+    cover: Qt.resolvedUrl("cover/CoverPage.qml")
     //allowedOrientations: defaultAllowedOrientations
 
     property int _lastNotificationId: 0


### PR DESCRIPTION
It seems the SailfishOS cover page was disabled some time ago. It seems it have useful information to show and allows more user interaction.
![Screenshot-24-10-11-11-27-40](https://github.com/user-attachments/assets/0c71cbcc-7fef-48a0-9161-02fe895ba80f)

The property was added in order to allow use it with other flavors. 
It was necessary to fix images path. The `styler.iconHeartrate` contain one more level so I have decided to use absolute path for now.