### PR TITLE
Update build instructions

### DIFF
--- a/documentation/build-instructions.md
+++ b/documentation/build-instructions.md
@@ -41,12 +41,12 @@ sudo apt install -y qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libkdb3-de
 ```
 
 Two dependencies can be found on git repos
-https://git.sailfishos.org/mer-core/nemo-qml-plugin-dbus
+https://github.com/sailfishos/nemo-qml-plugin-dbus
 and
-https://git.sailfishos.org/mer-core/qtmpris
+https://github.com/sailfishos/qtmpris.git/
 
 ```
-git clone https://git.sailfishos.org/mer-core/qtmpris.git
+git clone https://github.com/sailfishos/qtmpris.git/
 cd qtmpris
 qmake
 make
@@ -58,7 +58,7 @@ cd ..
 ```
 
 ```
-git clone https://git.sailfishos.org/mer-core/nemo-qml-plugin-dbus.git
+git clone https://github.com/sailfishos/nemo-qml-plugin-dbus
 cd nemo-qml-plugin-dbus
 qmake
 make

--- a/documentation/build-instructions.md
+++ b/documentation/build-instructions.md
@@ -142,7 +142,7 @@ clickable build --libs
 clickable desktop
 ```
 
-To build the libraries and the application for ARM architecture and install it on your device, follow these steps:
+To build the libraries and the application for the architecture of the connected device and install the app on your device, follow these steps:
 
 ```
 clickable build --libs --app --arch detect --skip-review

--- a/documentation/build-instructions.md
+++ b/documentation/build-instructions.md
@@ -142,7 +142,7 @@ clickable build --libs
 clickable desktop
 ```
 
-To build the application for ARM architecture and install it on your device, follow these steps:
+To build the libraries and the application for ARM architecture and install it on your device, follow these steps:
 
 ```
 clickable build --libs --app --arch detect --skip-review


### PR DESCRIPTION
This PR will update the repo links for the two sailfish plugins. It will also extend the note for UT build instructions to mention the libraries, since the command given will build both, the app and the libs.

Important for myself was, that the libs need to be build against the target architecture e.g. arm64. So this command needs to be run with a device attached. Or libs need to be build manually by specifying the correct architecture. Simply building will use the hosts arch which will fail. I hope my last rephrasing makes that clearer.