### PR TITLE
rename download to upload since files are uploaded onto the device

### DIFF
--- a/ui/qml/pages/BipFirmwarePage.qml
+++ b/ui/qml/pages/BipFirmwarePage.qml
@@ -4,7 +4,7 @@ import "../components/platform"
 
 PagePL {
     id: page
-    title: qsTr("Download File")
+    title: qsTr("Upload File")
 
     property string selectedFile: qsTr("None")
     property string fileVersion
@@ -19,7 +19,7 @@ PagePL {
 
         LabelPL {
             width: parent.width
-            text: qsTr("Select a file to download.");
+            text: qsTr("Select a file to upload.");
         }
 
         ValueButtonPL {

--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -30,7 +30,7 @@ PagePL {
             }
         }
         PageMenuItemPL {
-            text: qsTr("Download File")
+            text: qsTr("Upload File")
             onClicked: app.pages.push(Qt.resolvedUrl("BipFirmwarePage.qml"))
         }
         PageMenuItemPL {


### PR DESCRIPTION
I am not sure if I do miss something, but this menu and function seems to upload files to the watch, not load files from the watch. So I suggest renaming it to upload.