### PR TITLE
add init procedure for steps

### DIFF
--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -199,6 +199,11 @@ PagePL {
                     text: AmazfishConfig.profileFitnessGoal.toLocaleString()
                 }
             }
+            Component.onCompleted: {
+                if (_connected) {
+                    _InfoSteps = parseInt(DaemonInterfaceInstance.information(Amazfish.INFO_STEPS), 10) || 0;
+                }
+            }
         }
 
         SectionHeaderPL {


### PR DESCRIPTION
Unless I have missed it, but when opening the app the `_infoSteps` value does not get initialized. Only when visiting the steps page or manually uploading or so the var is assigned a value. So I suggest to initialize it - if a device is connected - in the onCompleted event.