### PR TITLE
show locale number format for steps

### DIFF
--- a/ui/qml/pages/StepsPage.qml
+++ b/ui/qml/pages/StepsPage.qml
@@ -25,7 +25,7 @@ PagePL {
             font.pixelSize: styler.themeFontSizeExtraLarge * 3
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: _InfoSteps > 0 ? _InfoSteps : graphStepSummary.lastValue
+            text: _InfoSteps.toLocaleString()
             horizontalAlignment: Text.AlignHCenter
         }
 

--- a/ui/qml/pages/StepsPage.qml
+++ b/ui/qml/pages/StepsPage.qml
@@ -25,7 +25,7 @@ PagePL {
             font.pixelSize: styler.themeFontSizeExtraLarge * 3
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: text: _InfoSteps > 0 ? _InfoSteps.toLocaleString() : graphStepSummary.lastValue
+            text: _InfoSteps > 0 ? _InfoSteps.toLocaleString() : graphStepSummary.lastValue
             horizontalAlignment: Text.AlignHCenter
         }
 

--- a/ui/qml/pages/StepsPage.qml
+++ b/ui/qml/pages/StepsPage.qml
@@ -25,7 +25,7 @@ PagePL {
             font.pixelSize: styler.themeFontSizeExtraLarge * 3
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: _InfoSteps > 0 ? _InfoSteps.toLocaleString() : graphStepSummary.lastValue
+            text: _InfoSteps > 0 ? _InfoSteps.toLocaleString() : graphStepSummary.lastValue.toLocaleString()
             horizontalAlignment: Text.AlignHCenter
         }
 

--- a/ui/qml/pages/StepsPage.qml
+++ b/ui/qml/pages/StepsPage.qml
@@ -25,7 +25,7 @@ PagePL {
             font.pixelSize: styler.themeFontSizeExtraLarge * 3
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: _InfoSteps.toLocaleString()
+            text: text: _InfoSteps > 0 ? _InfoSteps.toLocaleString() : graphStepSummary.lastValue
             horizontalAlignment: Text.AlignHCenter
         }
 


### PR DESCRIPTION
This PR will use the same locale number format for steps as on [FirstPage](https://github.com/piggz/harbour-amazfish/blob/master/ui/qml/pages/FirstPage.qml#L186). 

It will also drop showing the steps of the last day when steps are zero. I personally find it confusing to see a number there if I know I didn't do any steps. On other pages also zero is shown if there is no reading (yet). So I suggest dropping that part and show zero steps if there are zero steps.