### PR TITLE
add column with bpm tresholds and use round instead of floor

### DIFF
--- a/ui/qml/pages/HeartratePage.qml
+++ b/ui/qml/pages/HeartratePage.qml
@@ -85,44 +85,64 @@ PagePL {
 
         //Type summary
         Grid {
-            columns: 2
+            columns: 3
             spacing: styler.themePaddingMedium
-            width: parent.width
-            LabelPL { text: qsTr("Relaxed") }
-            Item { width: parent.width * 0.5; height: 50
+            width: parent.width - (styler.themePaddingMedium * 2)
+            LabelPL {text: qsTr("Relaxed")}
+            Item { 
+                width: parent.width * 0.5
+                height: 50
                 Rectangle { color: "grey"; width: parent.width * (relaxed  / total) ; height: parent.height }
-                LabelPL { text: Math.floor((relaxed / total) * 100) + "%"; anchors.centerIn: parent}
+                LabelPL { text: Math.round((relaxed / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL { text: qsTr("Light") }
-            Item { width: parent.width * 0.5; height: 50
+            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.5)))}
+
+            LabelPL {text: qsTr("Light")}
+            Item {
+                width: parent.width * 0.5
+                height: 50
                 Rectangle { color: "lightblue"; width: parent.width * (light  / total) ; height: parent.height }
-                LabelPL { text: Math.floor((light / total) * 100) + "%"; anchors.centerIn: parent}
+                LabelPL { text: Math.round((light / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL { text: qsTr("Intensive")}
-            Item { width: parent.width * 0.5; height: 50
+            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.6)))}
+
+            LabelPL {text: qsTr("Intensive")}
+            Item {
+                width: parent.width * 0.5
+                height: 50
                 Rectangle { color: "green"; width: parent.width * (intensive  / total) ; height: parent.height }
-                LabelPL { text: Math.floor((intensive / total) * 100) + "%"; anchors.centerIn: parent}
+                LabelPL { text: Math.round((intensive / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL { text: qsTr("Aerobic")}
-            Item { width: parent.width * 0.5; height: 50
+            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.7)))}
+
+            LabelPL {text: qsTr("Aerobic")}
+            Item {
+                width: parent.width * 0.5
+                height: 50
                 Rectangle { color: "yellow"; width: parent.width * (aerobic  / total) ; height: parent.height }
-                LabelPL { text: Math.floor((aerobic / total) * 100) + "%"; anchors.centerIn: parent}
+                LabelPL { text: Math.round((aerobic / total) * 100) + "%"; anchors.centerIn: parent}
             }
+            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.8)))}
 
-            LabelPL { text: qsTr("Anerobic")}
-            Item { width: parent.width * 0.5; height: 50
+            LabelPL {text: qsTr("Anerobic")}
+            Item {
+                width: parent.width * 0.5
+                height: 50
                 Rectangle { color: "orange"; width: parent.width * (anerobic  / total) ; height: parent.height }
-                LabelPL { text: Math.floor((anerobic / total) * 100) + "%"; anchors.centerIn: parent}
+                LabelPL { text: Math.round((anerobic / total) * 100) + "%"; anchors.centerIn: parent}
             }
+            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.9)))}
 
-            LabelPL { text: qsTr("VO2 Max") }
-            Item { width: parent.width * 0.5; height: 50
+            LabelPL {text: qsTr("VO2 Max")}
+            Item {
+                width: parent.width * 0.5
+                height: 50
                 Rectangle { color: "red"; width: parent.width * (vo2max  / total) ; height: parent.height }
-                LabelPL { text: Math.floor((vo2max / total) * 100) + "%"; anchors.centerIn: parent}
+                LabelPL { text: Math.round((vo2max / total) * 100) + "%"; anchors.centerIn: parent}
             }
+            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR())))}
         }
     }
-
 
     function updateGraphs() {
         graphHR.updateGraph(day);

--- a/ui/qml/pages/HeartratePage.qml
+++ b/ui/qml/pages/HeartratePage.qml
@@ -95,7 +95,7 @@ PagePL {
                 Rectangle { color: "grey"; width: parent.width * (relaxed  / total) ; height: parent.height }
                 LabelPL { text: Math.round((relaxed / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.5)))}
+            LabelPL {text: qsTr("≤ %1 BPM".arg(Math.round(maxHR()*0.5)))}
 
             LabelPL {text: qsTr("Light")}
             Item {
@@ -104,7 +104,7 @@ PagePL {
                 Rectangle { color: "lightblue"; width: parent.width * (light  / total) ; height: parent.height }
                 LabelPL { text: Math.round((light / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.6)))}
+            LabelPL {text: qsTr("≤ %1 BPM".arg(Math.round(maxHR()*0.6)))}
 
             LabelPL {text: qsTr("Intensive")}
             Item {
@@ -113,7 +113,7 @@ PagePL {
                 Rectangle { color: "green"; width: parent.width * (intensive  / total) ; height: parent.height }
                 LabelPL { text: Math.round((intensive / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.7)))}
+            LabelPL {text: qsTr("≤ %1 BPM".arg(Math.round(maxHR()*0.7)))}
 
             LabelPL {text: qsTr("Aerobic")}
             Item {
@@ -122,7 +122,7 @@ PagePL {
                 Rectangle { color: "yellow"; width: parent.width * (aerobic  / total) ; height: parent.height }
                 LabelPL { text: Math.round((aerobic / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.8)))}
+            LabelPL {text: qsTr("≤ %1 BPM".arg(Math.round(maxHR()*0.8)))}
 
             LabelPL {text: qsTr("Anerobic")}
             Item {
@@ -131,7 +131,7 @@ PagePL {
                 Rectangle { color: "orange"; width: parent.width * (anerobic  / total) ; height: parent.height }
                 LabelPL { text: Math.round((anerobic / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR()*0.9)))}
+            LabelPL {text: qsTr("≤ %1 BPM".arg(Math.round(maxHR()*0.9)))}
 
             LabelPL {text: qsTr("VO2 Max")}
             Item {
@@ -140,7 +140,7 @@ PagePL {
                 Rectangle { color: "red"; width: parent.width * (vo2max  / total) ; height: parent.height }
                 LabelPL { text: Math.round((vo2max / total) * 100) + "%"; anchors.centerIn: parent}
             }
-            LabelPL {text: qsTr("<= %1 BPM".arg(Math.round(maxHR())))}
+            LabelPL {text: qsTr("≤ %1 BPM".arg(Math.round(maxHR())))}
         }
     }
 


### PR DESCRIPTION
This PR will do two things in heart rate page:
1. it will use round instead of floor to calculate the category values to avoid larger differences when summing all up (sum should be 100%, but with floor can be easily 5% less, now at most 1% rounding difference)
2. it will add a third column with the actual threshold values which are used to calculate the categories, those values are important in my opinion, because a user might want to set a bpm warning on their watch (bip allows to do that) when exercising, but for that they need to now the value

![grafik](https://github.com/user-attachments/assets/8ab006d3-3d03-4cf9-9e1d-7ab980b067a8)
