### PR TITLE
Fixes #421: setTime upon connection to bangle.js

### DIFF
--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -175,6 +175,24 @@ void BangleJSDevice::initialise()
     }
 
     setConnectionState("authenticated");
+
+    setTime();
+}
+
+void BangleJSDevice::setTime() {
+    UARTService *uart = qobject_cast<UARTService*>(service(UARTService::UUID_SERVICE_UART));
+    if (!uart){
+        return;
+    }
+
+    qint64 ts;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+    ts = QDateTime::currentSecsSinceEpoch();
+#else
+    ts = QDateTime::currentDateTime().toTime_t();
+#endif
+    uart->tx(QByteArray(1, 0x10) + QString("setTime(" + QString::number(ts) + ");\n").toUtf8());
 }
 
 void BangleJSDevice::onPropertiesChanged(QString interface, QVariantMap map, QStringList list)

--- a/daemon/src/devices/banglejsdevice.h
+++ b/daemon/src/devices/banglejsdevice.h
@@ -37,6 +37,8 @@ public:
     //Weather
     void sendWeather(CurrentWeather *weather) override;
 
+    void setTime();
+
 protected:
     virtual void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
 


### PR DESCRIPTION
I have done brief testing with bangle.js device (during conference lunch break) and kirigami flavor (qt 5.15.8) . It worked for me. There is `#ifdef` for SailfishOS which wasn't tested (i.e. blind implementation).