### PR TITLE
pair function shoud invoke QBLEDevice::pair()

### DIFF
--- a/daemon/src/devices/asteroidosdevice.cpp
+++ b/daemon/src/devices/asteroidosdevice.cpp
@@ -78,7 +78,7 @@ void AsteroidOSDevice::pair()
     setConnectionState("pairing");
     emit connectionStateChanged();
 
-    QBLEDevice::connectToDevice();
+    QBLEDevice::pair();
 }
 
 

--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -20,7 +20,7 @@ void BangleJSDevice::pair()
     setConnectionState("pairing");
     emit connectionStateChanged();
 
-    QBLEDevice::connectToDevice();
+    QBLEDevice::pair();
 }
 
 int BangleJSDevice::supportedFeatures() const

--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -58,14 +58,15 @@ void PinetimeJFDevice::pair()
 {
     qDebug() << Q_FUNC_INFO;
 
-    m_needsAuth = false;
+    m_needsAuth = true;
     m_pairing = true;
     m_autoreconnect = true;
-    //disconnectFromDevice();
+    disconnectFromDevice();
     setConnectionState("pairing");
     emit connectionStateChanged();
 
-    QBLEDevice::connectToDevice();
+    QBLEDevice::pair();
+
 }
 
 int PinetimeJFDevice::supportedFeatures() const


### PR DESCRIPTION
I have discovered that `QBLEDevice::connectToDevice();` is used instead of `QBLEDevice::pair();` in InfiniTime. It seems to be legacy code intended to fix connection issues with older PineTime firmware.

The same code was copied and pasted into AsteroidOS.

I have tested this behavior with PineTime and AsteroidOS on Ubuntu Touch (Volla1), SailfishOS (PinePhone), and Kirigami (my desktop setup), and it works in my opinion much better than before.

I have noticed the same thing in Bangle.js code. I assume it will work better as well, but I currently don't have a device to test. Occasionally, I can borrow a device for testing, but it might take some time.

I have also observed that on Ubuntu Touch, the "system-wide" Authentication Agent seems to appear only when the Bluetooth Settings dialog is open. I suspect this is an issue with Ubuntu Touch. Previously, the dialog did not appear during pairing at all. - This was reported here https://gitlab.com/ubports/development/core/lomiri-system-settings/-/issues/379 

Note: It might be necessary to remove device or forget device in system setting first.