### PR TITLE
Add some brand colors

### DIFF
--- a/ui/harbour-amazfish-ui.appdata.xml
+++ b/ui/harbour-amazfish-ui.appdata.xml
@@ -26,6 +26,10 @@
   <developer id="@piggz@fosstodon.org">
     <name>Adam Pigg</name>
   </developer>
+  <branding>
+    <color type="primary" scheme_preference="light">#ff8446</color>
+    <color type="primary" scheme_preference="dark">#3a1d11</color>
+  </branding>
   <screenshots>
     <screenshot type="default">
       <image>https://github.com/piggz/harbour-amazfish/raw/2.2.4/screenshots/screenshot1.png</image>


### PR DESCRIPTION
Flatpak recommends settings some brand colors. 

https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/#has-primary-brand-colors

I took those two colors. However, I am not artist and my sense of good colors is limited:

Light `#ff8446`:
![rect1](https://github.com/user-attachments/assets/a948341b-e519-4411-9f2b-eefba4a76dda)

Dark `#3a1d11`:
![rect2](https://github.com/user-attachments/assets/35eed601-8eda-4129-99ab-25421d2e9b4e)
