### PR TITLE
fixes #432: avoid padStart on SailfishOS

### DIFF
--- a/ui/qml/pages/SleepPage.qml
+++ b/ui/qml/pages/SleepPage.qml
@@ -91,7 +91,10 @@ PagePL {
     function decimalToHourMin(decTime) {
         var totalMinutes = Math.round(decTime * 60);
         var hours = Math.floor(totalMinutes / 60);
-        var minutes = (totalMinutes % 60).toString().padStart(2, '0');
+        var minutes = (totalMinutes % 60);
+        if (minutes < 10) {
+            return hours + ":0" + minutes;
+        }
 
         return hours + ":" + minutes;
     }


### PR DESCRIPTION
It seems String prototype padStart() is not available on SailfishOS

Log contain following message:
```
Nov 29 07:06:12 PinePhone i[3056]: [W] unknown:94 - file:///usr/share/harbour-amazfish-ui/qml/pages/SleepPage.qml:94: TypeError: Property 'padStart' of object 0 is not a function
```