### PR TITLE
Hide back button when there isn't any page on stack

### DIFF
--- a/ui/qml/components/platform.uuitk/HeaderBarImpl.qml
+++ b/ui/qml/components/platform.uuitk/HeaderBarImpl.qml
@@ -29,6 +29,7 @@ UC.PageHeader {
     navigationActions: UC.Action {
         iconSource: styler.iconBack
         onTriggered: app.pages.pop()
+        visible: (app.pages.currentIndex > 0)
     }
     title: page.title
     width: page.width


### PR DESCRIPTION
There was back button on the FirstPage on Ubuntu Touch. The button had no purpose and was confusing. See screenshots from `clickable destkop`

![Screenshot from 2024-12-13 13-20-30](https://github.com/user-attachments/assets/8abff231-543a-4346-8f6e-dafdca960120)![Screenshot from 2024-12-13 13-19-44](https://github.com/user-attachments/assets/d59e7dc1-03a5-4caf-bfa0-7e166d898c7d)
