### PR TITLE
[Ubuntu Touch] Popup using notification

### DIFF
--- a/ui/qml/components/platform.uuitk/PopupPL.qml
+++ b/ui/qml/components/platform.uuitk/PopupPL.qml
@@ -1,1 +1,33 @@
-../platform.kirigami/PopupPL.qml
+import Nemo.DBus 2.0
+
+DBusInterface {
+    id: notificationsIface
+    bus: DBus.SessionBus
+    service: 'org.freedesktop.Notifications'
+    path: '/org/freedesktop/Notifications'
+    iface: 'org.freedesktop.Notifications'
+
+    function showMessage(msg) {
+
+        // https://specifications.freedesktop.org/notification-spec/latest/protocol.html
+        // https://wiki.ubuntu.com/Touch/Notifications
+
+        console.log(msg) // notification will not apear in `clickable desktop`
+
+        var app_icon = APPLICATION_FILE_DIR + "/../share/icons/hicolor/scalable/apps/harbour-amazfish-ui.svg"
+
+        notificationsIface.typedCall("Notify", [
+            { "type": "s", "value": "harbour-amazfish" },     // app_name
+            { "type": "u", "value": _lastNotificationId },    // replaces_id
+            { "type": "s", "value": app_icon },               // app_icon
+            { "type": "s", "value": msg },                    // summary
+            { "type": "s", "value": "" },                     // body
+            { "type": "as", "value": [] },                    // actions
+            { "type": "a{sv}", "value": {
+                "sound-file": "/usr/share/sounds/lomiri/notifications/Xylo.ogg",
+            }},                                               // hints
+            { "type": "i", "value": 5000 }                   // expire_timeout
+        ]);
+
+    }
+}

--- a/ui/qml/pages/DebugInfo.qml
+++ b/ui/qml/pages/DebugInfo.qml
@@ -193,7 +193,7 @@ PagePL {
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width * 0.8
             onClicked: {
-                app.showMessage("This is a test notification");
+                app.showMessage(qsTr("This is a test notification"));
             }
         }
         ButtonPL {

--- a/ui/src/harbour-amazfish-ui.cpp
+++ b/ui/src/harbour-amazfish-ui.cpp
@@ -127,6 +127,7 @@ int main(int argc, char *argv[])
     view->setSource(SailfishApp::pathTo("qml/harbour-amazfish.qml"));
     view->show();
 #elif UUITK_EDITION
+    view->rootContext()->setContextProperty("APPLICATION_FILE_DIR",  QFileInfo(QCoreApplication::applicationFilePath()).absolutePath());
     view->load("./share/harbour-amazfish-ui/qml/harbour-amazfish.qml");
 #else
     view->load(QUrl("qrc:/qml/harbour-amazfish.qml"));


### PR DESCRIPTION
I am wondering how the PopupPL should look like. In SailfishOS it is implemented as notification. 

This is a draft how it could look like:

![screenshot20241217_195139811](https://github.com/user-attachments/assets/6c011884-8739-44db-8c33-82c0b8bb97d3)

I am not sure why isn't the notification next other notification. Probably some parameter is wrong

The other option is to use Lomiri.Components.Popups. See https://ubports.gitlab.io/docs/api-docs/lomiriuserinterfacetoolkit/qml-lomiri-components-popups-popuputils.html