### PR TITLE
[Amazfit NEO] Use sampleSize 8 for activity fetch

### DIFF
--- a/daemon/src/devices/neodevice.cpp
+++ b/daemon/src/devices/neodevice.cpp
@@ -97,6 +97,8 @@ void NeoDevice::initialise()
 
     QString revision = softwareRevision();
     qDebug() << Q_FUNC_INFO << "Neo Firmware: " << revision;
+    m_ActivitySampleSize = 8;
+
 }
 
 


### PR DESCRIPTION
It seems Amazfit NEO is using 8 bytes for activity samples. 

In Gadgetbridge the AmazfitNeoSupport is at [1], the inheritance points to MiBand5Support [2] and there is return 8 in getActivitySampleSize(). Data parsing it self is in [3].

[1] https://codeberg.org/Freeyourgadget/Gadgetbridge/src/branch/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/amazfitneo/AmazfitNeoSupport.java
[2] https://codeberg.org/Freeyourgadget/Gadgetbridge/src/branch/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/miband5/MiBand5Support.java
[3] https://codeberg.org/Freeyourgadget/Gadgetbridge/src/branch/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/operations/fetch/FetchActivityOperation.java
[4] https://codeberg.org/Freeyourgadget/Gadgetbridge/src/commit/bbd0d8709de1846e151356d9afc3df677dc2abfe/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/operations/fetch/FetchActivityOperation.java#L149

Fixes #352