### PR TITLE
Don't wrap axis labels

### DIFF
--- a/ui/qml/components/GraphData.qml
+++ b/ui/qml/components/GraphData.qml
@@ -138,6 +138,7 @@ Item {
                 delegate: LabelPL {
                     text: createYLabel( (maxY-minY)/axisY.grid * index + minY)
                     width: styler.themeItemSizeLarge - 2*styler.themePaddingSmall
+                    wrapMode: Text.NoWrap
                     anchors {
                         top: (index == axisY.grid) ? parent.top : undefined
                         bottom: (index == axisY.grid) ? undefined : parent.bottom


### PR DESCRIPTION
I noticed that the y-axis labels are overlapping because the text is wrapped.

See the difference in the screenshot.

![screenshot20241231_095942951](https://github.com/user-attachments/assets/6c320fa8-59b9-448c-9bb4-48a1bb1793c7) ![screenshot20241231_100125006](https://github.com/user-attachments/assets/400b77f5-e3ad-4f39-9072-6325a393135d)
