### PR TITLE
[Ubuntu Touch] Popup: Remove sound, because its annoying

### DIFF
--- a/ui/qml/components/platform.uuitk/PopupPL.qml
+++ b/ui/qml/components/platform.uuitk/PopupPL.qml
@@ -23,10 +23,8 @@ DBusInterface {
             { "type": "s", "value": msg },                    // summary
             { "type": "s", "value": "" },                     // body
             { "type": "as", "value": [] },                    // actions
-            { "type": "a{sv}", "value": {
-                "sound-file": "/usr/share/sounds/lomiri/notifications/Xylo.ogg",
-            }},                                               // hints
-            { "type": "i", "value": 5000 }                   // expire_timeout
+            { "type": "a{sv}", "value": {}},                  // hints
+            { "type": "i", "value": 5000 }                    // expire_timeout
         ]);
 
     }


### PR DESCRIPTION
The popup is used for every synchronization quite often. The sound is a little annoying. Additionally, it hard codes some random system sound.
I am sorry for noise, I should see this before sending pull request ;-(