### PR TITLE
SportPage is not shown when mapboxgl-qml is not installed

### DIFF
--- a/rpm/harbour-amazfish.spec
+++ b/rpm/harbour-amazfish.spec
@@ -35,6 +35,7 @@ Requires:   kcoreaddons >= 5.31.0
 Requires:   libicu
 Requires:   kf5bluezqt
 Requires:   libkf5archive
+Requires:   mapboxgl-qml
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)


### PR DESCRIPTION
I can see following error messages in journal on pinephone when the mapboxgl-qml package is missing
```
led 10 15:32:33 PinePhone i[4969]: [W] unknown:1283 - file:///usr/lib64/qt5/qml/Sailfish/Silica/PageStack.qml:1283:13: QML AnimatedLoader: (file:///usr/share/harbour-amazfish-ui/qml/pages/SportPage.qml:3:1: module "MapboxMap" is not installed
                                       import MapboxMap 1.0
                                       ^)
led 10 15:32:33 PinePhone i[4969]: [W] unknown:113 - file:///usr/share/harbour-amazfish-ui/qml/pages/SportsSummaryPage.qml:113: Error: Cannot assign to non-existent property "activitytitle"
```