### PR TITLE
[SportSummaryPage] Use sharead Image.source to accelerate rendering of Icons and use Loader

### DIFF
--- a/ui/qml/pages/SportsSummaryPage.qml
+++ b/ui/qml/pages/SportsSummaryPage.qml
@@ -20,14 +20,12 @@ PageListPL {
     IconPL {
         id: sharedIconLocation
         iconName: styler.iconLocation
-        cache: true
         visible: false
     }
 
     IconPL {
         id: sharedIconTime
         iconName: styler.iconClock
-        cache: true
         visible: false
     }
 

--- a/ui/qml/pages/SportsSummaryPage.qml
+++ b/ui/qml/pages/SportsSummaryPage.qml
@@ -17,19 +17,36 @@ PageListPL {
         }
     }
 
+    IconPL {
+        id: sharedIconLocation
+        iconName: styler.iconLocation
+        cache: true
+        visible: false
+    }
+
+    IconPL {
+        id: sharedIconTime
+        iconName: styler.iconClock
+        cache: true
+        visible: false
+    }
+
     delegate: ListItemPL {
         id: listItem
         contentHeight: styler.themeItemSizeSmall + (styler.themePaddingMedium * 2)
 
-        IconPL
-        {
+        Loader {
             id: workoutImage
             anchors.top: parent.top
             anchors.topMargin: styler.themePaddingMedium
             x: styler.themePaddingMedium
             width: styler.themeItemSizeSmall
             height: width
-            iconName: styler.customIconPrefix + "icon-m-" + kindstring.toLowerCase() + styler.customIconSuffix
+            sourceComponent: IconPL {
+                iconSource: styler.customIconPrefix + "icon-m-" + kindstring.toLowerCase() + styler.customIconSuffix
+                width: styler.themeItemSizeSmall
+                height: width
+            }
         }
         LabelPL
         {
@@ -55,11 +72,11 @@ PageListPL {
             anchors.top: nameLabel.bottom
             anchors.left: workoutImage.right
             anchors.leftMargin: styler.themePaddingMedium
-            iconName: styler.iconLocation
+            width: distLabel.height
             height: distLabel.height
-            width: height
+            asynchronous: true
+            source: sharedIconLocation.source
         }
-
         LabelPL
         {
             id: distLabel
@@ -72,9 +89,10 @@ PageListPL {
             id: timeImage
             anchors.top: timeLabel.top
             anchors.right: timeLabel.left
-            iconName: styler.iconClock
+            width: timeLabel.height
             height: timeLabel.height
-            width: height
+            asynchronous: true
+            source: sharedIconTime.source
         }
         LabelPL
         {


### PR DESCRIPTION
According to my measurement on desktop the loading of Page changed from 1.6 s to 0.1 s after first load of data. It seams there is still some ugly leak which is causing delay in rendering of the page.

I was testing that just with kirigami right now.

Details are shown here: https://youtu.be/wfLNFML_pUA