### PR TITLE
Change filter to regexp, add Espruino to Bangle.js device

### DIFF
--- a/daemon/src/devicefactory.cpp
+++ b/daemon/src/devicefactory.cpp
@@ -59,7 +59,7 @@ AbstractDevice* DeviceFactory::createDevice(const QString &deviceName)
         return new PinetimeJFDevice(deviceName);
     }
 
-    if (deviceName.startsWith("Bangle.js")) {
+    if (deviceName.startsWith("Bangle.js") || deviceName.startsWith("Espruino")) {
         return new BangleJSDevice(deviceName);
     }
 

--- a/daemon/src/devicefactory.cpp
+++ b/daemon/src/devicefactory.cpp
@@ -59,7 +59,7 @@ AbstractDevice* DeviceFactory::createDevice(const QString &deviceName)
         return new PinetimeJFDevice(deviceName);
     }
 
-    if (deviceName.startsWith("Bangle.js") || deviceName.startsWith("Espruino")) {
+    if (deviceName.startsWith("Bangle.js") || deviceName.startsWith("Espruino") || deviceName.startsWith("Pixl.js") || deviceName.startsWith("Puck.js") || deviceName.startsWith("MDBT42Q")) {
         return new BangleJSDevice(deviceName);
     }
 

--- a/ui/qml/pages/PairPage.qml
+++ b/ui/qml/pages/PairPage.qml
@@ -16,7 +16,7 @@ PageListPL {
     //busy: discoveryModel.running || DaemonInterfaceInstance.pairing
 
     property string deviceType
-    property variant aliases
+    property string pattern
     property string _deviceName
     property string _deviceAddress
     property QtObject adapter: _bluetoothManager ? _bluetoothManager.usableAdapter : null
@@ -95,15 +95,13 @@ PageListPL {
             for (var i = 0; i < itemsCount; ++i) {
                 var item = items.get(i)
                 var visible = false;
-                if (item.model.FriendlyName.indexOf(deviceType) !== -1) {
-                    visible = true;
-                }
-                for (var j = 0; j < aliases.count; j++) {
-                    var aliasitem = aliases.get(j);
-                    if (item.model.FriendlyName.indexOf(aliasitem.name) !== -1) {
+                try {
+                    var regex = new RegExp(pattern);
+                    if (regex.test(item.model.FriendlyName)) {
                         visible = true;
                     }
-
+                } catch (e) {
+                    console.error("Invalid regex: " + pattern, e);
                 }
                 item.inVisible = visible
             }

--- a/ui/qml/pages/PairSelectDeviceType.qml
+++ b/ui/qml/pages/PairSelectDeviceType.qml
@@ -24,7 +24,7 @@ PageListPL {
         ListElement {
             deviceType: "AsteroidOS"
             icon: "../pics/devices/asteroidos.png"
-            pattern: "bass|sturgeon|narwhal|sparrow|dory|lenok|catfish|carp|smelt|anthias|pike|sawfish|ray/firefish|beluga|skipjack|koi|mooneye|swift|nemo|hoki|minnow|tetra|sprat|kingyo|medaka"
+            pattern: "bass|sturgeon|narwhal|sparrow|dory|lenok|catfish|carp|smelt|anthias|pike|sawfish|ray|firefish|beluga|skipjack|koi|mooneye|swift|nemo|hoki|minnow|tetra|sprat|kingyo|medaka"
         }
         ListElement {
             deviceType: "Amazfit Bip Watch"

--- a/ui/qml/pages/PairSelectDeviceType.qml
+++ b/ui/qml/pages/PairSelectDeviceType.qml
@@ -12,10 +12,10 @@ PageListPL {
             if (needsAuth) {
                 var authdialog = app.pages.push(Qt.resolvedUrl("./AuthKeyDialog.qml"));
                 authdialog.accepted.connect(function() {
-                    app.pages.push(Qt.resolvedUrl("./PairPage.qml"), { deviceType : deviceType, aliases: aliases} );
+                    app.pages.push(Qt.resolvedUrl("./PairPage.qml"), { deviceType : deviceType, pattern: pattern} );
                 })
             } else {
-                app.pages.push(Qt.resolvedUrl("./PairPage.qml"), { deviceType : deviceType, aliases: aliases} );
+                app.pages.push(Qt.resolvedUrl("./PairPage.qml"), { deviceType : deviceType, pattern: pattern} );
             }
         }
     }
@@ -24,132 +24,106 @@ PageListPL {
         ListElement {
             deviceType: "AsteroidOS"
             icon: "../pics/devices/asteroidos.png"
-            aliases: [
-                ListElement { name: 'bass' },
-                ListElement { name: 'sturgeon' },
-                ListElement { name: 'narwhal' },
-                ListElement { name: 'sparrow' },
-                ListElement { name: 'dory' },
-                ListElement { name: 'lenok' },
-                ListElement { name: 'catfish' },
-                ListElement { name: 'carp' },
-                ListElement { name: 'smelt' },
-                ListElement { name: 'anthias' },
-                ListElement { name: 'pike' },
-                ListElement { name: 'sawfish' },
-                ListElement { name: 'ray/firefish' },
-                ListElement { name: 'beluga' },
-                ListElement { name: 'skipjack' },
-                ListElement { name: 'koi' },
-                ListElement { name: 'mooneye' },
-                ListElement { name: 'swift' },
-                ListElement { name: 'nemo' },
-                ListElement { name: 'hoki' },
-                ListElement { name: 'minnow' },
-                ListElement { name: 'tetra' },
-                ListElement { name: 'sprat' },
-                ListElement { name: 'kingyo' },
-                ListElement { name: 'medaka' }
-            ]
+            pattern: "bass|sturgeon|narwhal|sparrow|dory|lenok|catfish|carp|smelt|anthias|pike|sawfish|ray/firefish|beluga|skipjack|koi|mooneye|swift|nemo|hoki|minnow|tetra|sprat|kingyo|medaka"
         }
         ListElement {
             deviceType: "Amazfit Bip Watch"
             icon: "../pics/devices/amazfit-bip.png"
-            aliases: []
+            pattern: "Amazfit Bip Watch"
         }
 
         ListElement {
             deviceType: "Amazfit Bip Lite"
             icon: "../pics/devices/amazfit-bip.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit Bip Lite"
         }
 
         ListElement {
             deviceType: "Amazfit Bip S"
             icon: "../pics/devices/amazfit-bips.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit Bip S"
         }
 
         ListElement {
             deviceType: "Amazfit GTS"
             icon: "../pics/devices/amazfit-gts.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit GTS"
         }
 
         ListElement {
             deviceType: "Amazfit Neo"
             icon: "../pics/devices/amazfit-neo.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit Neo"
         }
 
         ListElement {
             deviceType: "Amazfit GTS 2"
             icon: "../pics/devices/amazfit-gts2.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit GTS 2"
         }
 
         ListElement {
             deviceType: "Amazfit GTR"
             icon: "../pics/devices/amazfit-gtr.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit GTR"
         }
 
         ListElement {
             deviceType: "Amazfit GTR 2"
             icon: "../pics/devices/amazfit-gtr2.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit GTR 2"
         }
 
         ListElement {
             deviceType: "Amazfit Cor"
             icon: "../pics/devices/amazfit-cor.png"
-            aliases: []
+            pattern: "Amazfit Cor"
         }
 
         ListElement {
             deviceType: "MI Band 2"
             icon: "../pics/devices/miband2.png"
-            aliases: []
+            pattern: "MI Band 2"
         }
 
         ListElement {
             deviceType: "Mi Band 3"
             icon: "../pics/devices/miband3.png"
-            aliases: []
+            pattern: "Mi Band 3"
         }
 
         ListElement {
             deviceType: "Mi Smart Band 4"
             icon: "../pics/devices/miband4.png"
             auth: true
-            aliases: []
+            pattern: "Mi Smart Band 4"
         }
 
         ListElement {
             deviceType: "Amazfit Stratos 3"
             icon: "../pics/devices/miband4.png"
             auth: true
-            aliases: []
+            pattern: "Amazfit Stratos 3"
         }
 
         ListElement {
             deviceType: "InfiniTime"
             icon: "../pics/devices/pinetime.png"
             auth: false
-            aliases: [ ListElement { name: "Pinetime" } ]
+            pattern: "Pinetime"
         }
         ListElement {
             deviceType: "Bangle.js"
             icon: "../pics/devices/banglejs.png"
             auth: false
-            aliases: []
+            pattern: "Bangle\\.js.*|Pixl\\.js.*|Puck\\.js.*|MDBT42Q.*|Espruino.*"
         }
     }
 

--- a/ui/qml/pages/PairSelectDeviceType.qml
+++ b/ui/qml/pages/PairSelectDeviceType.qml
@@ -117,7 +117,7 @@ PageListPL {
             deviceType: "InfiniTime"
             icon: "../pics/devices/pinetime.png"
             auth: false
-            pattern: "Pinetime"
+            pattern: "Pinetime|InfiniTime"
         }
         ListElement {
             deviceType: "Bangle.js"


### PR DESCRIPTION
Bangle.js is supported also by other devices. Gadget bridge is using following regexp:
https://github.com/Freeyourgadget/Gadgetbridge/blob/a0948ee1cbc2a870f91d313f8e37df5f524465f7/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/devices/banglejs/BangleJSCoordinator.java#L75

I have reworked PairSelectDevice type in order to define regexp rather than aliases. The DeviceFactory is using startsWith anyway.

I was also wondering if we should rework connect page to match Device class other way around. The Gadgetbridge shows all hardware in bluetooth scan and allows pairing only when match with some pattern. Otherwise it can be useful allowing to pair with certain type even when regular expression doesn't match. Huami devices have big overlap, so It may work partially even without changes in code.

CI is failing due to https://github.com/piggz/harbour-amazfish/pull/468