### PR TITLE
QCoreApplication::quit() is not working before app.exec()

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -945,14 +945,14 @@ void DeviceInterface::registerDBus()
         if (!connection.registerService(SERVICE))
         {
             qCritical() << Q_FUNC_INFO << "Unable to register service. Quit.";
-            QCoreApplication::quit();
+            exit(1);
             return;
         }
 
         if (!connection.registerObject(PATH, this, QDBusConnection::ExportAllInvokables | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties))
         {
             qCritical() << Q_FUNC_INFO << "Unable to register objects. Quit.";
-            QCoreApplication::quit();
+            exit(1);
             return;
         }
         m_dbusRegistered = true;


### PR DESCRIPTION
According to the documentation https://doc.qt.io/qt-6/qcoreapplication.html#quit, `QCoreApplication::quit()` works only when `app.exec()` is running.

The `DeviceInterface::registerDBus` function is invoked within the `DeviceInterface` constructor, which occurs before `app.exec()`. As a result, the second instance of the daemon fails to register the DBus interface but does not exit immediately.

Steps to reproduce the issue:
-    Try to run two instances of the daemon.
-    Expected result: The second instance should exit immediately upon startup.