### PR TITLE
Added a counter to track the number of reconnections

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -154,6 +154,10 @@ QString DeviceInterface::connectionState() const
     }
     return m_device->connectionState();
 }
+int DeviceInterface::connectionStateChangedCount() const
+{
+    return m_connectionStateChangedCount;
+}
 
 HRMService *DeviceInterface::hrmService() const
 {
@@ -446,6 +450,7 @@ void DeviceInterface::onConnectionStateChanged()
 
         sendBufferedNotifications();
         updateCalendar();
+        m_connectionStateChangedCount++;
     } else {
         //Terminate running operations
         m_device->abortOperations();

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -47,6 +47,7 @@ public:
     Q_INVOKABLE void connectToDevice(const QString &address);
     Q_INVOKABLE void disconnect();
     Q_INVOKABLE QString connectionState() const;
+    Q_INVOKABLE int connectionStateChangedCount() const;
     Q_INVOKABLE bool operationRunning();
     Q_INVOKABLE bool supportsFeature(int f);
     Q_INVOKABLE int supportedFeatures();
@@ -91,6 +92,7 @@ private:
         QString body;
     };
 
+    int m_connectionStateChangedCount = 0;
     QString m_deviceAddress;
     QString m_deviceName;
     bool m_dbusRegistered = false;

--- a/ui/qml/pages/DebugInfo.qml
+++ b/ui/qml/pages/DebugInfo.qml
@@ -67,7 +67,7 @@ PagePL {
             color: styler.themeSecondaryHighlightColor
         }
         LabelPL {
-            text: qsTr("Connection State: ") + DaemonInterfaceInstance.connectionState
+            text: qsTr("Connection State: ") + DaemonInterfaceInstance.connectionState + " (" +DaemonInterfaceInstance.connectionStateChangedCount+")"
             color: styler.themeSecondaryHighlightColor
         }
         LabelPL {

--- a/ui/src/daemoninterface.cpp
+++ b/ui/src/daemoninterface.cpp
@@ -85,6 +85,14 @@ void DaemonInterface::changeConnectionState()
         return;
     }
 
+    auto watcherCount = new QDBusPendingCallWatcher(iface->asyncCall(QStringLiteral("connectionStateChangedCount")));
+    connect(watcherCount, &QDBusPendingCallWatcher::finished, this, [this, watcherCount]() {
+        QDBusReply<int> reply(watcherCount->reply());
+        auto count = reply.value();
+        m_connectionStateChangedCount = count;
+        emit connectionStateChangedCountChanged();
+    });
+
     auto watcher = new QDBusPendingCallWatcher(iface->asyncCall(QStringLiteral("connectionState")));
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher]() {
         QDBusReply<QString> reply(watcher->reply());
@@ -95,6 +103,7 @@ void DaemonInterface::changeConnectionState()
         }
         watcher->deleteLater();
     });
+
 }
 
 void DaemonInterface::connectToDevice(const QString &address)

--- a/ui/src/daemoninterface.h
+++ b/ui/src/daemoninterface.h
@@ -22,6 +22,7 @@ class DaemonInterface : public QObject
 
     //Device Interface
     Q_PROPERTY(QString connectionState MEMBER m_connectionState NOTIFY connectionStateChanged)
+    Q_PROPERTY(int connectionStateChangedCount MEMBER m_connectionStateChangedCount NOTIFY connectionStateChangedCountChanged)
     Q_PROPERTY(bool operationRunning READ operationRunning NOTIFY operationRunningChanged)
 
 public:
@@ -68,6 +69,7 @@ signals:
     void buttonPressed(int presses);
     void informationChanged(int infoKey, const QString& infoValue);
     void connectionStateChanged();
+    void connectionStateChangedCountChanged();
 
 private slots:
     void changeConnectionState();
@@ -90,6 +92,7 @@ private:
     void connectDatabase();
 
     QString m_connectionState;
+    int m_connectionStateChangedCount;
 
     bool operationRunning();
 


### PR DESCRIPTION
Himmi reported unstable Bluetooth connections with Amazfish and PineTime on the Sailfish OS forum. This change adds a counter to track reconnection attempts, making it easier to identify and debug connection stability issues. For more details, see the discussion:
https://forum.sailfishos.org/t/amazfish-on-c2-in-combination-with-pine-time/21741/6