### PR TITLE
Automatic switching of audio profiles

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -164,7 +164,7 @@ find_package(ICU REQUIRED COMPONENTS uc i18n data)
 find_package(KDb REQUIRED)
 
 if(FLAVOR STREQUAL "silica")
-    set(WATCHFISH_FEATURES "notificationmonitor;music;calendar;voicecall")
+    set(WATCHFISH_FEATURES "notificationmonitor;music;calendar;voicecall;soundprofile")
 
     pkg_check_modules(PULSE REQUIRED libpulse)
     target_include_directories(harbour-amazfishd PUBLIC ${PULSE_INCLUDE_DIRS})
@@ -177,7 +177,7 @@ if(FLAVOR STREQUAL "silica")
     target_link_libraries(harbour-amazfishd PUBLIC keepalive)
 
 elseif(FLAVOR STREQUAL "uuitk")
-    set(WATCHFISH_FEATURES "notificationmonitor;music;calendar;voicecall")
+    set(WATCHFISH_FEATURES "notificationmonitor;music;calendar;voicecall;soundprofile")
 
     pkg_check_modules(PULSE REQUIRED libpulse)
     target_include_directories(harbour-amazfishd PUBLIC ${PULSE_INCLUDE_DIRS})
@@ -185,7 +185,7 @@ elseif(FLAVOR STREQUAL "uuitk")
 
 
 else()
-    set(WATCHFISH_FEATURES "notificationmonitor;music;calendar")
+    set(WATCHFISH_FEATURES "notificationmonitor;music;calendar;soundprofile")
 endif()
 
 add_subdirectory(libwatchfish)

--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -459,12 +459,23 @@ void DeviceInterface::onConnectionStateChanged()
             sendAlert(tr("Amazfish"), tr("Connected"), tr("Phone and watch are connected"), true);
         }
 
+        if (m_device && m_device->supportsFeature(AbstractDevice::FEATURE_ALERT)
+            && AmazfishConfig::instance()->appSilenceConnect()) {
+            m_soundProfile.setProfile(watchfish::SoundProfile::Silent);
+        }
+
         sendBufferedNotifications();
         updateCalendar();
         m_connectionStateChangedCount++;
     } else {
         //Terminate running operations
         m_device->abortOperations();
+
+        if (m_device && m_device->supportsFeature(AbstractDevice::FEATURE_ALERT)
+            && AmazfishConfig::instance()->appSilenceConnect()) {
+            m_soundProfile.setProfile(watchfish::SoundProfile::General);
+        }
+
     }
     emit connectionStateChanged();
 }

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -25,6 +25,7 @@
 #include "libwatchfish/notificationmonitor.h"
 #include "libwatchfish/notification.h"
 #include "libwatchfish/calendarsource.h"
+#include "libwatchfish/soundprofile.h"
 #include "navigationinterface.h"
 
 class HRMService;
@@ -138,6 +139,7 @@ private:
 #endif
     watchfish::NotificationMonitor m_notificationMonitor;
     watchfish::CalendarSource m_calendarSource;
+    watchfish::SoundProfile m_soundProfile;
 
     //Notifications
     QQueue<WatchNotification> m_notificationBuffer;

--- a/lib/src/amazfishconfig.h
+++ b/lib/src/amazfishconfig.h
@@ -122,6 +122,7 @@ public:
     STRING_OPTION(QStringLiteral("pairedAddress"), pairedAddress, setPairedAddress, QString())
     STRING_OPTION(QStringLiteral("pairedName"),    pairedName,    setPairedName,    QString())
 
+    BOOL_OPTION(QStringLiteral("app/silenceconnect"),   appSilenceConnect,   setAppSilenceConnect,    false)
     BOOL_OPTION(QStringLiteral("app/notifyconnect"),    appNotifyConnect,    setAppNotifyConnect,    true)
     BOOL_OPTION(QStringLiteral("app/autosyncdata"),     appAutoSyncData,     setAppAutoSyncData,     true)
     BOOL_OPTION(QStringLiteral("app/notifylowbattery"), appNotifyLowBattery, setAppNotifyLowBattery, true)

--- a/ui/qml/pages/Settings-app.qml
+++ b/ui/qml/pages/Settings-app.qml
@@ -81,6 +81,14 @@ PagePL {
         }
 
         TextSwitchPL {
+            id: chkSilenceConnect
+            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+
+            width: parent.width
+            text: qsTr("Set silent profile on connect")
+        }
+
+        TextSwitchPL {
             id: chkNotifyConnect
             visible: supportsFeature(Amazfish.FEATURE_ALERT)
 
@@ -227,6 +235,7 @@ PagePL {
     }
 
     Component.onCompleted: {
+        chkSilenceConnect.checked = AmazfishConfig.appSilenceConnect;
         chkNotifyConnect.checked = AmazfishConfig.appNotifyConnect;
         sldWeatherRefresh.value = AmazfishConfig.appRefreshWeather;
         sldCalendarRefresh.value = AmazfishConfig.appRefreshCalendar;
@@ -241,6 +250,7 @@ PagePL {
     }
 
     function saveSettings() {
+        AmazfishConfig.appSilenceConnect = chkSilenceConnect.checked;
         AmazfishConfig.appNotifyConnect = chkNotifyConnect.checked;
         AmazfishConfig.appRefreshWeather = sldWeatherRefresh.value;
         AmazfishConfig.appRefreshCalendar = sldCalendarRefresh.value;


### PR DESCRIPTION
- [ ] This branch is based on cmake branch https://github.com/piggz/harbour-amazfish/pull/436

Allows to switch automatically between silent and general profile when smartwatch connected and disconnected.

I have tested the feature with Ubuntu Touch and SailfishOS

- [x] And requires changes in libwatchfish https://github.com/piggz/libwatchfish/pull/9

Fixes: #353