### PR TITLE
[qble] call bluez::adapter::RemoveDevice() to unpair device

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -1,5 +1,5 @@
 #include "deviceinterface.h"
-
+#include "bluezadapter.h"
 #include "deviceinfoservice.h"
 #include "alertnotificationservice.h"
 #include "hrmservice.h"
@@ -144,6 +144,17 @@ void DeviceInterface::disconnect()
     qDebug() << Q_FUNC_INFO;
     if (m_device) {
         m_device->disconnectFromDevice();
+    }
+}
+
+void DeviceInterface::unpair()
+{
+    qDebug() << Q_FUNC_INFO;
+    if (m_device) {
+        BluezAdapter adapter;
+        adapter.setAdapterPath(AmazfishConfig::instance()->localAdapter());
+        adapter.removeDevice(m_deviceAddress);
+
     }
 }
 

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -46,6 +46,7 @@ public:
     Q_INVOKABLE QString pair(const QString &name, const QString &address);
     Q_INVOKABLE void connectToDevice(const QString &address);
     Q_INVOKABLE void disconnect();
+    Q_INVOKABLE void unpair();
     Q_INVOKABLE QString connectionState() const;
     Q_INVOKABLE bool operationRunning();
     Q_INVOKABLE bool supportsFeature(int f);

--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -11,6 +11,10 @@ PagePL {
 
     function unpairAccepted() {
         DaemonInterfaceInstance.disconnect();
+        DaemonInterfaceInstance.unpair()
+        AmazfishConfig.pairedAddress = "";
+        AmazfishConfig.pairedName = "";
+
     }
 
     pageMenu: PageMenuPL {

--- a/ui/qml/pages/PairPage.qml
+++ b/ui/qml/pages/PairPage.qml
@@ -114,8 +114,6 @@ PageListPL {
             contentHeight: styler.themeItemSizeLarge
 //            visible: model.FriendlyName.indexOf(deviceType) >= 0
             onClicked: {
-                AmazfishConfig.pairedAddress = "";
-                AmazfishConfig.pairedName = "";
                 stopDiscovery();
                 _deviceName = model.FriendlyName;
                 _deviceAddress = AmazfishConfig.localAdapter+"/dev_" + model.Address.replace(/:/g, '_');

--- a/ui/src/daemoninterface.cpp
+++ b/ui/src/daemoninterface.cpp
@@ -113,6 +113,15 @@ void DaemonInterface::disconnect()
     iface->call(QStringLiteral("disconnect"));
 }
 
+void DaemonInterface::unpair()
+{
+    if (!iface || !iface->isValid()) {
+        return;
+    }
+    iface->call(QStringLiteral("unpair"));
+}
+
+
 bool DaemonInterface::supportsFeature(Amazfish::Feature f)
 {
     if (!iface || !iface->isValid()) {

--- a/ui/src/daemoninterface.h
+++ b/ui/src/daemoninterface.h
@@ -30,6 +30,7 @@ public:
 
     Q_INVOKABLE void connectToDevice(const QString &address);
     Q_INVOKABLE void disconnect();
+    Q_INVOKABLE void unpair();
     Q_INVOKABLE bool supportsFeature(Amazfish::Feature f);
     Q_INVOKABLE int supportedFeatures();
 


### PR DESCRIPTION
One of my observations is that trying to pair already paired devices doesn't work. This should improve the experience when hopping between devices. 

Right now it is not very well tested, but I believe this is one of scenarios I do very often.

- [x] Depends on https://github.com/piggz/qble/pull/7

CI failed also because https://github.com/piggz/harbour-amazfish/pull/468