### PR TITLE
Battery service payload format check

### DIFF
--- a/daemon/src/services/batteryservice.cpp
+++ b/daemon/src/services/batteryservice.cpp
@@ -21,10 +21,12 @@ void BatteryService::characteristicRead(const QString &characteristic, const QBy
 {
     qDebug() << Q_FUNC_INFO << "Read:" << characteristic << value;
     if (characteristic == UUID_CHARACTERISTIC_BATTERY_LEVEL) {
-        m_batteryLevel = value[0];
-        emit informationChanged(AbstractDevice::INFO_BATTERY, QString::number(m_batteryLevel));
+        if (value.length() == 1) {
+            m_batteryLevel = value[0];
+            emit informationChanged(AbstractDevice::INFO_BATTERY, QString::number(m_batteryLevel));
+        }
     } else {
-        qWarning() << "Unknown value";
+        qWarning() << "Unknown characteristic";
     }
 }
 

--- a/daemon/src/services/batteryservice.cpp
+++ b/daemon/src/services/batteryservice.cpp
@@ -24,6 +24,8 @@ void BatteryService::characteristicRead(const QString &characteristic, const QBy
         if (value.length() == 1) {
             m_batteryLevel = value[0];
             emit informationChanged(AbstractDevice::INFO_BATTERY, QString::number(m_batteryLevel));
+        } else {
+            qWarning() << "Invalid length";
         }
     } else {
         qWarning() << "Unknown characteristic";


### PR DESCRIPTION
I have seen some segfaults because of invalid battery service data. 
Similar checks are also in other services. For example:
https://github.com/piggz/harbour-amazfish/blob/d0508a6dbdd3cf6b2f380f3512d15d1956acbc7c/daemon/src/services/infinitimemotionservice.cpp#L33-L37