### PR TITLE
Ubuntu touch user metrics

### DIFF
--- a/click/harbour-amazfish.apparmor
+++ b/click/harbour-amazfish.apparmor
@@ -1,5 +1,6 @@
 {
     "policy_groups": [
+        "usermetrics"
     ],
     "policy_version": 20.04,
     "template": "unconfined"

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -22,6 +22,7 @@ dependencies_target:
 - libkf5coreaddons-dev
 - libdbus-1-dev
 - libtelepathy-qt5-dev
+- libusermetricsinput1-dev
 
 libraries:
   qtmpris:

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+./src/achievements.cpp
 ./src/activitycoordinate.cpp
 ./src/activitykind.cpp
 ./src/activitysample.cpp
@@ -93,6 +94,7 @@ set(SOURCES
 )
 
 set(HEADERS
+./src/achievements.h
 ./src/activitycoordinate.h
 ./src/activitykind.h
 ./src/activitysample.h

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -216,7 +216,10 @@ elseif(FLAVOR STREQUAL "uuitk")
     target_include_directories(harbour-amazfishd PUBLIC ${PULSE_INCLUDE_DIRS})
     target_link_libraries(harbour-amazfishd PUBLIC ${PULSE_LIBRARIES} pulse-simple)
 
+    pkg_check_modules(LIBUSERMETRICSINPUT REQUIRED libusermetricsinput-1)
 
+    target_include_directories(harbour-amazfishd PUBLIC ${LIBUSERMETRICSINPUT_INCLUDE_DIRS})
+    target_link_libraries(harbour-amazfishd PUBLIC ${LIBUSERMETRICSINPUT_LIBRARIES})
 else()
     set(WATCHFISH_FEATURES "notificationmonitor;music;calendar;soundprofile")
 endif()

--- a/daemon/src/achievements.cpp
+++ b/daemon/src/achievements.cpp
@@ -1,0 +1,73 @@
+#include "achievements.h"
+
+#ifdef UUITK_EDITION
+#include <libusermetricsinput/MetricManager.h>
+using namespace UserMetricsInput;
+#endif
+
+Achievements::Achievements(QObject *parent)
+    : QObject(parent)
+{
+    loreStepMessages = {
+        {0.0,  tr("The journey begins, adventurer. Only <b>%1</b> steps — the Shire is still in sight.")},
+        {0.25, tr("You’ve crossed the Brandywine. <b>%1</b> steps down — trolls ahead!")},
+        {0.5,  tr("Halfway to Mordor. <b>%1</b> steps walked and second breakfast missed.")},
+        {0.8,  tr("Mount Doom is on the horizon. <b>%1</b> steps behind you — don't drop the ring yet!")},
+        {1.0,  tr("The ring is cast into the fire. <b>%1</b> steps done — Middle-earth is saved!")},
+        {1.2,  tr("You kept walking after saving the world?! <b>%1</b> steps — you’re a true legend. 🧙")},
+        {2.0,  tr("The Hobbit, or There and Back Again — <b>%1</b> steps and second breakfast earned!")}
+    };
+
+     stepMessages = {
+        {0.0,  tr("Let's get moving! You've taken only <b>%1</b> steps so far.")},
+        {0.25, tr("Warming up! <b>%1</b> steps done — keep going!")},
+        {0.5,  tr("You're halfway there. <b>%1</b> steps so far!")},
+        {0.8,  tr("Almost there! Just a bit more — <b>%1</b> steps already!")},
+        {1.0,  tr("Goal reached! <b>%1</b> steps — you can have that cake now 🎉")},
+        {1.2,  tr("You smashed it! <b>%1</b> steps — time to rest or go for bonus steps?")}
+    };
+}
+
+void Achievements::updateStepsStatus(int steps, int goal)
+{
+
+#ifdef UUITK_EDITION
+    MetricManagerPtr manager(MetricManager::getInstance());
+    MetricPtr metric(
+        manager->add(
+            MetricParameters("uk.co.piggz.harbour-amazfish.steps-metric")
+              .formatString(selectStepsMessage(steps, goal))
+              .emptyDataString("No data")
+              .textDomain("harbour-amazfish")
+        )
+    );
+    metric->update(static_cast<double>(steps));
+    qDebug() << "metric-update(double steps)" << steps;
+#endif
+
+}
+
+QString Achievements::selectStepsMessage(int steps, double goal)
+{
+    QDate today = QDate::currentDate();
+    std::map<float, QString> usedMap;
+
+    if (today.month() == 3 && today.day() == 25) {
+//        qDebug() << "Tolkien reading day easter egg!";
+        usedMap = loreStepMessages;
+    } else {
+        usedMap = stepMessages;
+    }
+
+    double reached = (goal > 0) ? steps / static_cast<double>(goal) : 0.0;
+
+    qDebug() << Q_FUNC_INFO  << reached << " " << steps << " " << goal;
+
+    for (const auto& entry : usedMap) {
+        if (entry.first > reached) {
+            return entry.second.arg(steps);
+        }
+    }
+
+    return usedMap.rbegin()->second.arg(steps);
+}

--- a/daemon/src/achievements.h
+++ b/daemon/src/achievements.h
@@ -1,0 +1,24 @@
+#ifndef ACHIEVEMENTS_H
+#define ACHIEVEMENTS_H
+
+#include <QString>
+#include <QObject>
+#include <QDebug>
+#include <map>
+#include <memory>
+#include <QDate>
+
+class Achievements : public QObject
+{
+    Q_OBJECT
+public:
+    explicit Achievements(QObject *parent = nullptr);
+    void updateStepsStatus(int steps, int goal);
+
+private:
+    std::map<float, QString> loreStepMessages;
+    std::map<float, QString> stepMessages;
+    QString selectStepsMessage(int steps, double goal);
+};
+
+#endif // ACHIEVEMENTS_H

--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -550,25 +550,14 @@ void DeviceInterface::slot_informationChanged(AbstractDevice::Info key, const QS
             m_lastBatteryLevel = battery_level;
         }
     }
-#ifdef UUITK_EDITION
     if (key == AbstractDevice::INFO_STEPS) {
         bool conversionOk = false;
         int steps = val.toInt(&conversionOk);
         if (conversionOk) {
-            MetricManagerPtr manager(MetricManager::getInstance());
-            MetricPtr metric(
-                manager->add(
-                    MetricParameters("uk.co.piggz.harbour-amazfish.steps-metric")
-                      .formatString("<b>%1</b> steps made today")
-                      .emptyDataString("No steps measured today")
-                      .textDomain("harbour-amazfish")
-                )
-            );
-            metric->update((double)steps);
-            qDebug() << "metric-update(double steps)" << steps;
+            auto goal = AmazfishConfig::instance()->profileFitnessGoal();
+            m_achievements.updateStepsStatus(steps, goal);
         }
     }
-#endif
 
     emit informationChanged(key, val);
 }

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -27,6 +27,7 @@
 #include "libwatchfish/calendarsource.h"
 #include "libwatchfish/soundprofile.h"
 #include "navigationinterface.h"
+#include "achievements.h"
 
 class HRMService;
 class MiBand2Service;
@@ -135,6 +136,8 @@ private:
     watchfish::NotificationMonitor m_notificationMonitor;
     watchfish::CalendarSource m_calendarSource;
     watchfish::SoundProfile m_soundProfile;
+
+    Achievements m_achievements;
 
     //Notifications
     QQueue<AbstractDevice::WatchNotification> m_notificationBuffer;


### PR DESCRIPTION
The goal is to display the message `%1 steps made today` on the lock screen, similar to the example in the UBports documentation:
https://docs.ubports.com/de/latest/appdev/guides/user-metrics.html

![screenshot20250412_111342762](https://github.com/user-attachments/assets/37293af7-bdc8-4d26-b038-4872fadcb46e)

I suspect there may be an issue with internationalization (i18n), since Amazfish uses lupdate and lrelease, while other UBports apps use gettext. The libuserinput library tries to set the textDomain() to load translations independently.