### PR TITLE
Use DeviceType for DeviceFactory instead of name

### DIFF
--- a/daemon/src/devicefactory.cpp
+++ b/daemon/src/devicefactory.cpp
@@ -14,88 +14,39 @@
 #include "dk08device.h"
 #include "zepposdevice.h"
 
-AbstractDevice* DeviceFactory::createDevice(const QString &deviceName)
-{
-    qDebug() << Q_FUNC_INFO <<": requested device of type:" << deviceName;
+using DeviceCreator = std::function<AbstractDevice*(const QString &)>;
 
-    if (deviceName == "Amazfit Bip Watch") {
-        return new BipDevice(deviceName);
-    }
+static const QMap<QString, DeviceCreator> deviceMap = {
+    { "Amazfit Bip Watch", [](const QString &name) { return new BipDevice(name); } },
+    { "Amazfit GTS", [](const QString &name) { return new GtsDevice(name); } },
+    { "Amazfit Neo", [](const QString &name) { return new NeoDevice(name); } },
+    { "Amazfit GTS 2", [](const QString &name) { return new Gts2Device(name); } },
+    { "Amazfit GTR", [](const QString &name) { return new GtrDevice(name); } },
+    { "Amazfit GTR 2", [](const QString &name) { return new Gtr2Device(name); } },
+    { "Amazfit Bip Lite", [](const QString &name) { return new BipLiteDevice(name); } },
+    { "Amazfit Bip S", [](const QString &name) { return new BipSDevice(name); } },
+    { "Amazfit Stratos 3", [](const QString &name) { return new GtsDevice(name); } },
+    { "Mi Smart Band 4", [](const QString &name) { return new BipLiteDevice(name); } },
+    { "Amazfit Balance", [](const QString &name) { return new ZeppOSDevice(name); } },
+    { "InfiniTime", [](const QString &name) { return new PinetimeJFDevice(name); } },
+    { "Pebble", [](const QString &name) { return new PebbleDevice(name); } },
+    { "Bangle.js", [](const QString &name) { return new BangleJSDevice(name); } },
+    { "Kospet DK08", [](const QString &name) { return new DK08Device(name); } },
+    { "AsteroidOS", [](const QString &name) { return new AsteroidOSDevice(name); } },
 
-    if (deviceName == "Amazfit GTS") {
-        return new GtsDevice(deviceName);
-    }
-
-    if (deviceName == "Amazfit Neo") {
-        return new NeoDevice(deviceName);
-    }
-
-    if (deviceName == "Amazfit GTS 2") {
-        return new Gts2Device(deviceName);
-    }
-
-    if (deviceName == "Amazfit GTR") {
-        return new GtrDevice(deviceName);
-    }
-
-    if (deviceName == "Amazfit GTR 2") {
-        return new Gtr2Device(deviceName);
-    }
-
-    if (deviceName == "Amazfit Bip Lite") {
-        return new BipLiteDevice(deviceName);
-    }
-
-    if (deviceName == "Amazfit Bip S") {
-        return new BipSDevice(deviceName);
-    }
-
-    if (deviceName == "Amazfit Stratos 3") {
-        return new GtsDevice(deviceName);
-    }
-
-    if (deviceName == "Mi Smart Band 4") {
-        return new BipLiteDevice(deviceName);
-    }
-
-    if (deviceName == "Amazfit Balance") {
-        return new ZeppOSDevice(deviceName);
-    }
-
-    if (deviceName == "InfiniTime" || deviceName == "Pinetime-JF") {
-        return new PinetimeJFDevice(deviceName);
-    }
-
-    if (deviceName.startsWith("Pebble Time")) {
-        return new PebbleDevice(deviceName);
-    }
-
-    if (deviceName.startsWith("Bangle.js") || deviceName.startsWith("Espruino") || deviceName.startsWith("Pixl.js") || deviceName.startsWith("Puck.js") || deviceName.startsWith("MDBT42Q")) {
-        return new BangleJSDevice(deviceName);
-    }
-
-    if (deviceName == "DK08") {
-        return new DK08Device(deviceName);
-    }
-
-    QList<QString> asteroidDevices = {
-        "AsteroidOS",
-        "bass", "sturgeon", "narwhal", "sparrow", "dory",
-        "lenok", "catfish", "carp", "smelt", "anthias",
-        "pike", "sawfish", "ray", "firefish", "beluga", "skipjack",
-        "koi", "mooneye", "swift", "nemo", "hoki",
-        "minnow", "tetra", "sprat", "kingyo", "medaka"
+    { "Amazfit Cor", [](const QString &name) { return new BipLiteDevice(name); } },
+    { "Mi Band 3", [](const QString &name) { return new BipLiteDevice(name); } },
+    { "Mi Band 2", [](const QString &name) { return new BipLiteDevice(name); } },
     };
 
-    for (auto iterator = asteroidDevices.begin(); iterator != asteroidDevices.end(); ++iterator) {
-        if (deviceName == *iterator) {
-            return new AsteroidOSDevice(deviceName);
-        }
+AbstractDevice* DeviceFactory::createDevice(const QString &deviceName, const QString &deviceType)
+{
+    qDebug() << Q_FUNC_INFO <<": requested device of type:" << deviceName << deviceType;
+
+    if (deviceMap.contains(deviceType)) {
+        return deviceMap.value(deviceType)(deviceName);
     }
 
-    qDebug() << Q_FUNC_INFO << ": no suitable devices found, creating a Bip device as default";
-    return new BipDevice(deviceName);
-
-    //!TODO allow the user to choose the device type
-    //return nullptr;
+    qWarning() << "DeviceCreator not found";
+    return nullptr;
 }

--- a/daemon/src/devicefactory.h
+++ b/daemon/src/devicefactory.h
@@ -7,7 +7,7 @@
 class DeviceFactory
 {
 public:
-    static AbstractDevice* createDevice(const QString &deviceName);
+    static AbstractDevice* createDevice(const QString &deviceName, const QString &deviceType);
 };
 
 #endif

--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -37,7 +37,7 @@ DeviceInterface::DeviceInterface()
     auto config = AmazfishConfig::instance();
 
     //Create a device object
-    m_device = DeviceFactory::createDevice(config->pairedName());
+    m_device = DeviceFactory::createDevice(config->pairedName(), config->pairedType());
     if (m_device) {
         connect(m_device, &AbstractDevice::connectionStateChanged, this, &DeviceInterface::onConnectionStateChanged, Qt::UniqueConnection);
         connect(m_device, &AbstractDevice::message, this, &DeviceInterface::message, Qt::UniqueConnection);
@@ -125,7 +125,7 @@ QString DeviceInterface::pair(const QString &name, const QString &deviceType, co
     if (m_device) {
         delete m_device;
     }
-    m_device = DeviceFactory::createDevice(name);
+    m_device = DeviceFactory::createDevice(name, deviceType);
 
     if (m_device) {
         m_device->setDevicePath(address);

--- a/lib/src/amazfishconfig.h
+++ b/lib/src/amazfishconfig.h
@@ -121,6 +121,7 @@ public:
 
     STRING_OPTION(QStringLiteral("pairedAddress"), pairedAddress, setPairedAddress, QString())
     STRING_OPTION(QStringLiteral("pairedName"),    pairedName,    setPairedName,    QString())
+    STRING_OPTION(QStringLiteral("pairedType"),    pairedType,    setPairedType,    QString())
 
     BOOL_OPTION(QStringLiteral("app/silenceconnect"),   appSilenceConnect,   setAppSilenceConnect,    false)
     BOOL_OPTION(QStringLiteral("app/notifyconnect"),    appNotifyConnect,    setAppNotifyConnect,    true)

--- a/ui/qml/components/DeviceListModel.qml
+++ b/ui/qml/components/DeviceListModel.qml
@@ -69,7 +69,7 @@ ListModel {
     }
 
     ListElement {
-        deviceType: "MI Band 2"
+        deviceType: "Mi Band 2"
         icon: "../pics/devices/miband2.png"
         pattern: "MI Band 2"
     }

--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -14,6 +14,7 @@ PagePL {
         DaemonInterfaceInstance.unpair()
         AmazfishConfig.pairedAddress = "";
         AmazfishConfig.pairedName = "";
+        AmazfishConfig.pairedType = "";
 
     }
 

--- a/ui/qml/pages/PairDevicePage.qml
+++ b/ui/qml/pages/PairDevicePage.qml
@@ -15,10 +15,10 @@ PageListPL {
     property bool busy: (adapter && adapter.discovering && !page.count) || DaemonInterfaceInstance.connectionState == "pairing"
     //busy: discoveryModel.running || DaemonInterfaceInstance.pairing
 
-    property string deviceType
     property string pattern
     property string _deviceName
     property string _deviceAddress
+    property string _deviceType
     property QtObject adapter: _bluetoothManager ? _bluetoothManager.usableAdapter : null
     property QtObject _bluetoothManager : BluezQt.Manager
 
@@ -64,7 +64,8 @@ PageListPL {
             if (DaemonInterfaceInstance.connectionState == "paired" || DaemonInterfaceInstance.connectionState == "connected") {
                 AmazfishConfig.pairedAddress = _deviceAddress
                 AmazfishConfig.pairedName = _deviceName
-                console.log("Paired with", AmazfishConfig.pairedName, AmazfishConfig.pairedAddress, _deviceName, _deviceAddress);
+                AmazfishConfig.pairedType = _deviceType
+                console.log("Paired with", AmazfishConfig.pairedName, AmazfishConfig.pairedType, AmazfishConfig.pairedAddress, _deviceName, _deviceAddress);
                 app.pages.pop(app.rootPage);
             }
         }
@@ -139,16 +140,17 @@ PageListPL {
                         page.stopDiscovery();
                         _deviceName = model.FriendlyName;
                         _deviceAddress = AmazfishConfig.localAdapter+"/dev_" + model.Address.replace(/:/g, '_');
-                        DaemonInterfaceInstance.pair(_deviceName, device.deviceType, _deviceAddress)
+                        _deviceType = device.deviceType
+                        DaemonInterfaceInstance.pair(_deviceName, _deviceType, _deviceAddress);
                     })
                     return;
                 }
 
                 stopDiscovery();
                 _deviceName = model.FriendlyName;
+                _deviceType = device.deviceType;
                 _deviceAddress = AmazfishConfig.localAdapter+"/dev_" + model.Address.replace(/:/g, '_');
-
-                DaemonInterfaceInstance.pair(_deviceName, device.deviceType, _deviceAddress)
+                DaemonInterfaceInstance.pair(_deviceName, _deviceType, _deviceAddress);
             }
 
             Item {


### PR DESCRIPTION
Next step in pairing refactoring. This allows to use random hardware with specific implementation. Next step should be dialog to show DeviceListModel and allow to select deviceType manually. 

Important for release notes: It is necessary to pair device again.

I need to test it carefully