### PR TITLE
Move WatchNotification into amazfish.h, add conversion to QVariantMap

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -183,7 +183,7 @@ HRMService *DeviceInterface::hrmService() const
 
 void DeviceInterface::onNotification(watchfish::Notification *notification)
 {
-    AbstractDevice::WatchNotification n;
+    Amazfish::WatchNotification n;
     n.id = notification->id();
     n.appId = notification->appId();
     n.appName = notification->appName();
@@ -463,7 +463,7 @@ void DeviceInterface::onConnectionStateChanged()
             m_dbusHRM->setHRMService(hrmService());
         }
         if (AmazfishConfig::instance()->appNotifyConnect() && m_notificationBuffer.isEmpty()) {
-            AbstractDevice::WatchNotification n;
+            Amazfish::WatchNotification n;
             n.id = 0;
             n.appId = "uk.co.piggz.amazfish";
             n.appName = tr("Amazfish");
@@ -539,7 +539,7 @@ void DeviceInterface::slot_informationChanged(AbstractDevice::Info key, const QS
         if (battery_level != m_lastBatteryLevel) {
             log_battery_level(battery_level);
             if (battery_level <= 10 && battery_level < m_lastBatteryLevel && AmazfishConfig::instance()->appNotifyLowBattery()) {
-                AbstractDevice::WatchNotification n;
+                Amazfish::WatchNotification n;
                 n.id = 0;
                 n.appId = "uk.co.piggz.amazfish";
                 n.appName = tr("Amazfish");
@@ -665,7 +665,7 @@ void DeviceInterface::onEventTimer()
     if (m_eventlist.isEmpty())
         return;
     watchfish::CalendarEvent event = m_eventlist.takeFirst();
-    AbstractDevice::WatchNotification n;
+    Amazfish::WatchNotification n;
     n.id = 0;
     n.appId = "uk.co.piggz.amazfish.calendar";
     n.appName = tr("Calendar");
@@ -688,7 +688,7 @@ void DeviceInterface::sendBufferedNotifications()
 {
     qDebug() << Q_FUNC_INFO;
     while (m_notificationBuffer.count() > 0) {
-        AbstractDevice::WatchNotification n = m_notificationBuffer.dequeue();
+        Amazfish::WatchNotification n = m_notificationBuffer.dequeue();
         if (m_device->supportsFeature(AbstractDevice::FEATURE_ALERT)){
             qDebug() << "Sending notification";
             sendAlert(n);
@@ -902,7 +902,11 @@ QString DeviceInterface::information(int i)
     return QString();
 }
 
-void DeviceInterface::sendAlert(const AbstractDevice::WatchNotification &notification, bool allowDuplicate)
+void DeviceInterface::sendAlert(const QVariantMap &notification, bool allowDuplicate) {
+    sendAlert(Amazfish::WatchNotification::fromQVariantMap(notification), allowDuplicate);
+}
+
+void DeviceInterface::sendAlert(const Amazfish::WatchNotification &notification, bool allowDuplicate)
 {
     qDebug() << Q_FUNC_INFO;
 
@@ -916,7 +920,7 @@ void DeviceInterface::sendAlert(const AbstractDevice::WatchNotification &notific
     if (m_device && m_device->connectionState() == "authenticated" && m_device->supportsFeature(AbstractDevice::FEATURE_ALERT)){
         qDebug() << "Snding alert to device";
 
-        AbstractDevice::WatchNotification t = notification;
+        Amazfish::WatchNotification t = notification;
 
         if (AmazfishConfig::instance()->appTransliterate()) {
             t.appName = Transliterator::convert(notification.appName);

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -72,8 +72,10 @@ public:
     Q_INVOKABLE void downloadSportsData();
     Q_INVOKABLE void downloadActivityData();
     Q_INVOKABLE void refreshInformation();
+
     Q_INVOKABLE QString information(int i);
-    Q_INVOKABLE void sendAlert(const AbstractDevice::WatchNotification &notification, bool allowDuplicate = false);
+    Q_INVOKABLE void sendAlert(const QVariantMap &notification, bool allowDuplicate = false);
+    Q_INVOKABLE void sendAlert(const Amazfish::WatchNotification &notification, bool allowDuplicate = false);
     Q_INVOKABLE void incomingCall(const QString &caller);
     Q_INVOKABLE void incomingCallEnded();
     Q_INVOKABLE void applyDeviceSetting(int s);
@@ -140,7 +142,7 @@ private:
     Achievements m_achievements;
 
     //Notifications
-    QQueue<AbstractDevice::WatchNotification> m_notificationBuffer;
+    QQueue<Amazfish::WatchNotification> m_notificationBuffer;
 
     //Database
     KDbDriver *m_dbDriver = nullptr;

--- a/daemon/src/devices/abstractdevice.h
+++ b/daemon/src/devices/abstractdevice.h
@@ -2,6 +2,7 @@
 #ifndef ABSTRACTDEVICE_H
 #define ABSTRACTDEVICE_H
 
+#include "amazfish.h"
 #include "qble/qbledevice.h"
 #include "weather/currentweather.h"
 #include "abstractfirmwareinfo.h"
@@ -82,15 +83,6 @@ public:
     };
     Q_ENUM(Event)
 
-    struct WatchNotification
-    {
-        int id;
-        QString appId;
-        QString appName;
-        QString summary;
-        QString body;
-    };
-
     explicit AbstractDevice(const QString &pairedName, QObject *parent = nullptr);
     
     virtual void pair() override;
@@ -121,7 +113,7 @@ public:
     virtual QString information(Info i) const;
     virtual void applyDeviceSetting(Settings s);
     virtual void rebootWatch();
-    virtual void sendAlert(const AbstractDevice::WatchNotification &notification) = 0;
+    virtual void sendAlert(const Amazfish::WatchNotification &notification) = 0;
     virtual void incomingCall(const QString &caller) = 0;
     virtual void incomingCallEnded() = 0;
     virtual void sendEventReminder(int id, const QDateTime &dt, const QString &event);

--- a/daemon/src/devices/asteroidosdevice.cpp
+++ b/daemon/src/devices/asteroidosdevice.cpp
@@ -33,7 +33,7 @@ AbstractFirmwareInfo *AsteroidOSDevice::firmwareInfo(const QByteArray &bytes)
     return nullptr;
 }
 
-void AsteroidOSDevice::sendAlert(const AbstractDevice::WatchNotification &notification)
+void AsteroidOSDevice::sendAlert(const Amazfish::WatchNotification &notification)
 {
     qDebug() << Q_FUNC_INFO;
 

--- a/daemon/src/devices/asteroidosdevice.h
+++ b/daemon/src/devices/asteroidosdevice.h
@@ -12,7 +12,7 @@ public:
 
     virtual int supportedFeatures() const override;
     virtual QString deviceType() const override;
-    virtual void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    virtual void sendAlert(const Amazfish::WatchNotification &notification) override;
     virtual void incomingCall(const QString &caller) override;
     virtual void incomingCallEnded() override;
     virtual AbstractFirmwareInfo *firmwareInfo(const QByteArray &bytes) override;

--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -45,7 +45,7 @@ void BangleJSDevice::abortOperations()
 
 }
 
-void BangleJSDevice::sendAlert(const AbstractDevice::WatchNotification &notification)
+void BangleJSDevice::sendAlert(const Amazfish::WatchNotification &notification)
 {
     qDebug() << Q_FUNC_INFO;
 

--- a/daemon/src/devices/banglejsdevice.h
+++ b/daemon/src/devices/banglejsdevice.h
@@ -14,7 +14,7 @@ public:
     QString deviceType() const override;
     void abortOperations() override;
 
-    void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    void sendAlert(const Amazfish::WatchNotification &notification) override;
     void incomingCall(const QString &caller) override;
     void incomingCallEnded() override;
 

--- a/daemon/src/devices/dk08device.cpp
+++ b/daemon/src/devices/dk08device.cpp
@@ -34,7 +34,7 @@ void DK08Device::pair()
     QBLEDevice::pair();
 }
 
-void DK08Device::sendAlert(const AbstractDevice::WatchNotification &notification) {
+void DK08Device::sendAlert(const Amazfish::WatchNotification &notification) {
     qDebug() << Q_FUNC_INFO;
     DK08NUSService *nus = qobject_cast<DK08NUSService*>(service(DK08NUSService::UUID_SERVICE_NUS));
     m_alert_id = (m_alert_id + 1) % 32;

--- a/daemon/src/devices/dk08device.h
+++ b/daemon/src/devices/dk08device.h
@@ -12,7 +12,7 @@ public:
 
     int supportedFeatures() const override;
     QString deviceType() const override;
-    void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    void sendAlert(const Amazfish::WatchNotification &notification) override;
     void incomingCall(const QString &caller) override;
     void incomingCallEnded() override;
     void downloadActivityData() override;

--- a/daemon/src/devices/huamidevice.cpp
+++ b/daemon/src/devices/huamidevice.cpp
@@ -174,7 +174,7 @@ void HuamiDevice::rebootWatch()
 
 }
 
-void HuamiDevice::sendAlert(const AbstractDevice::WatchNotification &notification)
+void HuamiDevice::sendAlert(const Amazfish::WatchNotification &notification)
 {
     AlertNotificationService *alert = qobject_cast<AlertNotificationService*>(service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION));
     if (alert) {
@@ -207,7 +207,7 @@ void HuamiDevice::navigationRunning(bool running)
     } else {
         msg = tr("Navigation Stopped");
     }
-    AbstractDevice::WatchNotification n;
+    Amazfish::WatchNotification n;
     n.id = 0;
     n.appId = "uk.co.piggz.amazfish.navigation";
     n.appName = "navigation";
@@ -221,7 +221,7 @@ void HuamiDevice::navigationNarrative(const QString &flag, const QString &narrat
 {
     Q_UNUSED(flag)
 
-    AbstractDevice::WatchNotification n;
+    Amazfish::WatchNotification n;
     n.id = 0;
     n.appId = "uk.co.piggz.amazfish.navigation";
     n.appName = "navigation";

--- a/daemon/src/devices/huamidevice.h
+++ b/daemon/src/devices/huamidevice.h
@@ -27,7 +27,7 @@ public:
 
     void applyDeviceSetting(Settings s) override;
 
-    virtual void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    virtual void sendAlert(const Amazfish::WatchNotification &notification) override;
     void incomingCall(const QString &caller) override;
     void incomingCallEnded() override;
 

--- a/daemon/src/devices/pebbledevice.cpp
+++ b/daemon/src/devices/pebbledevice.cpp
@@ -35,7 +35,7 @@ void PebbleDevice::pair()
 }
 
 
-void PebbleDevice::sendAlert(const AbstractDevice::WatchNotification &notification) {
+void PebbleDevice::sendAlert(const Amazfish::WatchNotification &notification) {
     qDebug() << Q_FUNC_INFO;
 }
 

--- a/daemon/src/devices/pebbledevice.h
+++ b/daemon/src/devices/pebbledevice.h
@@ -12,7 +12,7 @@ public:
 
     virtual int supportedFeatures() const override;
     virtual QString deviceType() const override;
-    virtual void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    virtual void sendAlert(const Amazfish::WatchNotification &notification) override;
     virtual void incomingCall(const QString &caller) override;
     virtual void incomingCallEnded() override;
 

--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -91,7 +91,7 @@ void PinetimeJFDevice::abortOperations()
     }
 }
 
-void PinetimeJFDevice::sendAlert(const AbstractDevice::WatchNotification &notification)
+void PinetimeJFDevice::sendAlert(const Amazfish::WatchNotification &notification)
 {
     AlertNotificationService *alert = qobject_cast<AlertNotificationService*>(service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION));
     if (alert) {

--- a/daemon/src/devices/pinetimejfdevice.h
+++ b/daemon/src/devices/pinetimejfdevice.h
@@ -15,7 +15,7 @@ public:
     QString deviceType() const override;
     void abortOperations() override;
 
-    void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    void sendAlert(const Amazfish::WatchNotification &notification) override;
     void incomingCall(const QString &caller) override;
     void incomingCallEnded() override;
 

--- a/daemon/src/devices/zeppos/zepposnotificationservice.cpp
+++ b/daemon/src/devices/zeppos/zepposnotificationservice.cpp
@@ -7,7 +7,7 @@ ZeppOsNotificationService::ZeppOsNotificationService(ZeppOSDevice *device) : Abs
     m_endpoint = 0x001e;
 }
 
-void ZeppOsNotificationService::sendAlert(const AbstractDevice::WatchNotification &notification) const
+void ZeppOsNotificationService::sendAlert(const Amazfish::WatchNotification &notification) const
 {
     qDebug() << Q_FUNC_INFO;
 

--- a/daemon/src/devices/zeppos/zepposnotificationservice.h
+++ b/daemon/src/devices/zeppos/zepposnotificationservice.h
@@ -32,7 +32,7 @@ public:
     void handlePayload(const QByteArray &payload) override;
     QString name() const override;
 
-    void sendAlert(const AbstractDevice::WatchNotification &notification) const;
+    void sendAlert(const Amazfish::WatchNotification &notification) const;
     void incomingCall(const QString &caller);
 };
 

--- a/daemon/src/devices/zepposdevice.cpp
+++ b/daemon/src/devices/zepposdevice.cpp
@@ -59,7 +59,7 @@ AbstractFirmwareInfo *ZeppOSDevice::firmwareInfo(const QByteArray &bytes)
     return nullptr;
 }
 
-void ZeppOSDevice::sendAlert(const AbstractDevice::WatchNotification &notification)
+void ZeppOSDevice::sendAlert(const Amazfish::WatchNotification &notification)
 {
     qDebug() << Q_FUNC_INFO;
     m_notificationService->sendAlert(notification);

--- a/daemon/src/devices/zepposdevice.h
+++ b/daemon/src/devices/zepposdevice.h
@@ -23,7 +23,7 @@ public:
     AbstractFirmwareInfo *firmwareInfo(const QByteArray &bytes) override;
 
     //Overrides from AbstractDevice
-    void sendAlert(const AbstractDevice::WatchNotification &notification) override;
+    void sendAlert(const Amazfish::WatchNotification &notification) override;
     void incomingCall(const QString &caller) override;
     void incomingCallEnded() override;
     void requestManualHeartrate() const override;

--- a/daemon/src/services/asteroidnotificationservice.cpp
+++ b/daemon/src/services/asteroidnotificationservice.cpp
@@ -11,7 +11,7 @@ AsteroidNotificationService::AsteroidNotificationService(const QString &path, QO
     connect(this, &QBLEService::characteristicChanged, this, &AsteroidNotificationService::characteristicChanged);
 }
 
-void AsteroidNotificationService::sendAlert(const AbstractDevice::WatchNotification &notification)
+void AsteroidNotificationService::sendAlert(const Amazfish::WatchNotification &notification)
 {
 //    qDebug() << Q_FUNC_INFO << sender << subject << message;
 
@@ -30,7 +30,7 @@ void AsteroidNotificationService::incomingCall(const QString &caller)
 {
     qDebug() << Q_FUNC_INFO << caller;
     m_lastVoiceCallNotification++;
-    AbstractDevice::WatchNotification n;
+    Amazfish::WatchNotification n;
 
     n.appId = "incoming-call";
     n.appName = "incoming-call";

--- a/daemon/src/services/asteroidnotificationservice.h
+++ b/daemon/src/services/asteroidnotificationservice.h
@@ -14,7 +14,7 @@ public:
     static const char* UUID_CHARACTERISTIC_NOTIFICATION_UPDATE;
     static const char* UUID_CHARACTERISTIC_NOTIFICATION_FEEDBACK;
 
-    Q_INVOKABLE void sendAlert(const AbstractDevice::WatchNotification &notification);
+    Q_INVOKABLE void sendAlert(const Amazfish::WatchNotification &notification);
     Q_INVOKABLE void removeNotification(unsigned int id);
     Q_INVOKABLE void incomingCall(const QString &caller);
     Q_INVOKABLE void incomingCallEnded();

--- a/lib/src/amazfish.h
+++ b/lib/src/amazfish.h
@@ -2,6 +2,7 @@
 #define AMAZFISH_H
 
 #include <QObject>
+#include <QVariantMap>
 
 //Container class for enums
 class Amazfish : public QObject {
@@ -78,11 +79,42 @@ public:
     };
     Q_ENUM(Settings)
 
+    struct WatchNotification
+    {
+        int id;
+        QString appId;
+        QString appName;
+        QString summary;
+        QString body;
+
+        QVariantMap toQVariantMap() const {
+            QVariantMap map;
+            map["id"] = id;
+            map["appId"] = appId;
+            map["appName"] = appName;
+            map["summary"] = summary;
+            map["body"] = body;
+            return map;
+        }
+
+        static WatchNotification fromQVariantMap(const QVariantMap &map) {
+            WatchNotification n;
+            n.id = map.value("id").toInt();
+            n.appId = map.value("appId").toString();
+            n.appName = map.value("appName").toString();
+            n.summary = map.value("summary").toString();
+            n.body = map.value("body").toString();
+            return n;
+        }
+    };
+
+
     static QString activityToString(Amazfish::ActivityType type);
 };
 Q_DECLARE_METATYPE(Amazfish::ActivityType)
 Q_DECLARE_METATYPE(Amazfish::Feature)
 Q_DECLARE_METATYPE(Amazfish::Info)
 Q_DECLARE_METATYPE(Amazfish::Settings)
+Q_DECLARE_METATYPE(Amazfish::WatchNotification)
 
 #endif // AMAZFISH_H

--- a/ui/src/daemoninterface.cpp
+++ b/ui/src/daemoninterface.cpp
@@ -215,10 +215,19 @@ QString DaemonInterface::information(Amazfish::Info i)
 
 void DaemonInterface::sendAlert(const QString &sender, const QString &subject, const QString &message, bool allowDuplicate)
 {
+
+    Amazfish::WatchNotification n = {
+        .id = 0,
+        .appId = "uk.co.piggz.amazfish",
+        .appName = sender,
+        .summary = subject,
+        .body = message
+    };
+
     if (!iface || !iface->isValid()) {
         return;
     }
-    iface->call(QStringLiteral("sendAlert"), sender, subject, message, allowDuplicate);
+    iface->call(QStringLiteral("sendAlert"), n.toQVariantMap(), allowDuplicate);
 }
 
 void DaemonInterface::incomingCall(const QString &caller)


### PR DESCRIPTION
The WatchNotification struct was moved into `lib/src/amazfish.h` to be able to reference that from UI. Additionally, I have created toQVariantMap fromQVariantMap conversions to be able pass it via dbus.

The interface function was overloaded to be able use it via dbus:
```
void DeviceInterface::sendAlert(const QVariantMap &notification, bool allowDuplicate)
void DeviceInterface::sendAlert(const Amazfish::WatchNotification &notification, bool allowDuplicate)
```