### PR TITLE
kirigami LabelPL shoudn't have default padding

### DIFF
--- a/ui/qml/components/platform.qtcontrols/LabelPL.qml
+++ b/ui/qml/components/platform.qtcontrols/LabelPL.qml
@@ -23,9 +23,6 @@ import QtQuick.Layouts 1.12
 Label {
     Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
 
-    leftPadding: styler.themeHorizontalPageMargin
-    rightPadding: styler.themeHorizontalPageMargin
-
     elide: {
         if (truncMode === truncModes.elide) return Text.ElideRight;
         if (truncMode === truncModes.fade) return Text.ElideRight;

--- a/ui/qml/pages/SportsSummaryPage.qml
+++ b/ui/qml/pages/SportsSummaryPage.qml
@@ -87,6 +87,7 @@ PageListPL {
             id: timeImage
             anchors.top: timeLabel.top
             anchors.right: timeLabel.left
+            anchors.rightMargin: styler.themePaddingMedium
             width: timeLabel.height
             height: timeLabel.height
             asynchronous: true


### PR DESCRIPTION
SFOS/UBports Label doesn't padding by default either

Left with padding (old version), Right without padding (new version)
![image](https://github.com/user-attachments/assets/6220830e-0c33-47c5-ac54-3070fba3cc4c)

Left with padding (old version), Right without padding (new version)
![image](https://github.com/user-attachments/assets/6044bc36-656d-4143-95f4-7bb328a18b17)

However, some settings pages needs now explicit padding for labels, but this is at least the same as other platforms.
