### PR TITLE
Fix sport details icons

### DIFF
--- a/ui/qml/pages/SportPage.qml
+++ b/ui/qml/pages/SportPage.qml
@@ -63,7 +63,7 @@ PagePL {
                 Layout.preferredWidth: styler.themeItemSizeLarge
                 Layout.preferredHeight: styler.themeItemSizeLarge
                 Layout.alignment: Qt.AlignLeft
-                iconName: styler.customIconPrefix + "icon-m-" + getKindString(kindstring) + styler.customIconSuffix
+                iconSource: styler.customIconPrefix + "icon-m-" + getKindString(kindstring) + styler.customIconSuffix
             }
 
             LabelPL
@@ -186,7 +186,7 @@ PagePL {
                         map.fitView(trackPointsTemporary);
                     }
                 }
-                Image
+                IconPL
                 {
                     anchors.fill: parent
                     source: "../pics/map_btn_center.png"
@@ -213,7 +213,7 @@ PagePL {
                         bMapMaximized = !bMapMaximized;
                     }
                 }
-                Image
+                IconPL
                 {
                     anchors.fill: parent
                     source: (map.height === page.height) ? "../pics/map_btn_min.png" : "../pics/map_btn_max.png"


### PR DESCRIPTION
Sport Icon wasn't visible at all
Map icons wasn't visible well, now is color taken from theme.

ubports dark
![screenshot20250516_111505409](https://github.com/user-attachments/assets/3e7e4753-aa26-4cd0-9f2e-82ccee015749)

ubports light
![screenshot20250516_113706355](https://github.com/user-attachments/assets/ad95b929-b0bd-4b2a-828b-ce2b8564ee79)

sailfish os
![Screenshot-25-05-16-11-40-32](https://github.com/user-attachments/assets/1b8be9d2-9ac2-437b-b380-f3a07d276d4b)

kirigami
![image](https://github.com/user-attachments/assets/976908f3-d4bb-49aa-901a-dce2a4915661)

