### PR TITLE
Make sure that items have same alignment

### DIFF
--- a/ui/qml/pages/SportsSummaryPage.qml
+++ b/ui/qml/pages/SportsSummaryPage.qml
@@ -62,7 +62,8 @@ PageListPL {
             anchors.top: parent.top
             anchors.topMargin: styler.themePaddingMedium
             anchors.right: parent.right
-            anchors.rightMargin: styler.themePaddingSmall
+            anchors.rightMargin: styler.themePaddingMedium
+            width: listItem.width / 3
             text: startdate
         }
         IconPL {


### PR DESCRIPTION
TimeLabel and DateLabel are now aligned
- the right padding was Medium and Small
- the width wasn't defined on Date.

Ubuntu Touch
![screenshot20250516_113553628](https://github.com/user-attachments/assets/a9500c8a-445e-4a66-a3c5-ae2d06a5e949)

previously SFOS
![Screenshot-25-01-17-16-37-49](https://github.com/user-attachments/assets/36b03df3-bb78-4a90-9299-943a45731fe8)

now SFOS
![Screenshot-25-05-16-11-40-20](https://github.com/user-attachments/assets/6cd817fc-126e-4b66-a5aa-918117778742)

now Kirigami
![Screenshot at 2025-05-16 11-42-44](https://github.com/user-attachments/assets/4e09ab88-f117-4eb0-86a8-2372d87f78ae)

