### PR TITLE
It seems there are some negative values which breaks syncing

### DIFF
--- a/daemon/src/operations/abstractfetchoperation.cpp
+++ b/daemon/src/operations/abstractfetchoperation.cpp
@@ -12,7 +12,7 @@ QDateTime AbstractFetchOperation::lastActivitySync()
 {
     qlonglong ls = AmazfishConfig::instance()->value(m_lastSyncKey).toLongLong();
 
-    if (ls == 0) {
+    if (ls <= 0) {
         return QDateTime::currentDateTime().addDays(-100);
     }
 


### PR DESCRIPTION
I had following log:
```
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.658 : void DeviceInterface::updateCalendar()
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.660 : void DeviceInterface::onRefreshTimer() Auto syncing activity data
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.661 : bool AbstractOperationService::registerOperation(AbstractOperation*)
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.661 : Setting the current operation
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.662 : QDateTime AbstractFetchOperation::lastActivitySync() : Last sync was  -3600000 QDateTime(1970-01-01 00:00:00.000 CET Qt::LocalTime)
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.663 : virtual void ActivityFetchOperation::start(QBLEService*) : Last sync was  QDateTime(1970-01-01 00:00:00.000 CET Qt::LocalTime)
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.664 : UTC offset it  0
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.664 : converted date QDateTime(1969-12-31 23:00:00.000 UTC Qt::UTC) to "\xB1\x07\f\x1F\x17\x00\x00\x00"
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.664 : Starting notify for  "00000005-0000-3512-2118-0009af100700"
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.671 : Starting notify for  "00000004-0000-3512-2118-0009af100700"
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.677 : Writing to  "00000004-0000-3512-2118-0009af100700" : "0101b1070c1f17000000"
May 19 12:40:13 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:13.678 : void QBLECharacteristic::writeValue(const QByteArray&) const "0101b1070c1f17000000"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.570 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000004-0000-3512-2118-0009af100700" "10010100000000e90705130c2800>
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.571 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&)
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.571 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&) "\x10\x01\x01\x00\x00\x00\x00\xE9\x07\x05\x13\f(\x00\b"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.572 : Date length is  8 "\xE9\x07\x05\x13\f(\x00\b"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.572 : Watch timezone is: QTimeZone("UTC")
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.575 : System timezone is QTimeZone("Europe/Prague") "Europe/Prague"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.577 : About to transfer data from  QDateTime(2025-05-19 12:40:00.000 CEST Qt::TimeZone Europe/Prague ) expected length: 0
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.577 : Writing to  "00000004-0000-3512-2118-0009af100700" : "02"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.578 : void QBLECharacteristic::writeValue(const QByteArray&) const "02"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.659 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000004-0000-3512-2118-0009af100700" "100204"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.660 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&)
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.661 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&) "\x10\x02\x04"
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.662 : virtual bool ActivityFetchOperation::finished(bool) Last sample time saved as  "" 0 -3600000
May 19 12:40:14 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:14.677 : virtual bool ActivityFetchOperation::finished(bool) Last record was  QDateTime(Invalid)
May 19 12:40:16 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:16.053 : void HRMService::characteristicChanged(const QString&, const QByteArray&) Changed: "00002a37-0000-1000-8000-00805f9b34fb" "\x00O"
May 19 12:40:16 ubuntu-phablet harbour-amazfishd[7912]: 2025-05-19 12:40:16.054 : void DeviceInterface::slot_informationChanged(AbstractDevice::Info, const QString&) AbstractDevice::INFO_HEARTRATE "79"
```
Not sure where `-3600000` (aka `QDateTime(1969-12-31 23:00:00.000 UTC Qt::UTC)` ) comes from. It is probably some default value. 

I was able to see some syncing of data, but now it looks stucked on some date:

```
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.165 : bool AbstractOperationService::registerOperation(AbstractOperation*)
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.166 : Setting the current operation
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.167 : QDateTime AbstractFetchOperation::lastActivitySync() : Last sync was  1744478100000 QDateTime(2025-04-12 19:15:00.000 CEST Qt::LocalTime)
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.169 : virtual void ActivityFetchOperation::start(QBLEService*) : Last sync was  QDateTime(2025-04-12 19:15:00.000 CEST Qt::LocalTime)
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.169 : UTC offset it  0
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.169 : converted date QDateTime(2025-04-12 17:15:00.000 UTC Qt::UTC) to "\xE9\x07\x04\f\x11\x0F\x00\x00"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.170 : Starting notify for  "00000005-0000-3512-2118-0009af100700"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.175 : Starting notify for  "00000004-0000-3512-2118-0009af100700"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.181 : Writing to  "00000004-0000-3512-2118-0009af100700" : "0101e907040c110f0000"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.182 : void QBLECharacteristic::writeValue(const QByteArray&) const "0101e907040c110f0000"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.972 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000004-0000-3512-2118-0009af100700" "10010107000000e907040c13080004"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.973 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&) "\x10\x01\x01\x07\x00\x00\x00\xE9\x07\x04\f\x13\b\x00\x04"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.973 : bool AbstractFetchOperation::handleStartDateResponse(const QByteArray&)
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.974 : Date length is  8 "\xE9\x07\x04\f\x13\b\x00\x04"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.974 : Watch timezone is: QTimeZone("UTC")
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.976 : System timezone is QTimeZone("Europe/Prague") "Europe/Prague"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.978 : About to transfer data from  QDateTime(2025-04-12 19:08:00.000 CEST Qt::TimeZone Europe/Prague ) expected length: 7
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.979 : Writing to  "00000004-0000-3512-2118-0009af100700" : "02"
May 23 11:42:05 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:05.979 : void QBLECharacteristic::writeValue(const QByteArray&) const "02"
May 23 11:42:05 ubuntu-phablet aa-exec[5651]: qml: Připravuje se na přenos dat z so dub 12 19:08:00 2025 CEST
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.093 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000005-0000-3512-2118-0009af100700" "00f92800ff00259400f01f00ff000fa100"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.093 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 37 148 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.094 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 15 161 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.096 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000005-0000-3512-2118-0009af100700" "01f00000ff0003a500f00000ff0003a500"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.096 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 3 165 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.097 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 3 165 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.104 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000005-0000-3512-2118-0009af100700" "02f30000ff0011a500f30000ff0027a500"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.105 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 17 165 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.105 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 39 165 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.109 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000005-0000-3512-2118-0009af100700" "03f30000ff0031a700"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.109 : virtual void ActivityFetchOperation::handleData(const QByteArray&) Sample data missed: 0 49 167 0
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.134 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000004-0000-3512-2118-0009af100700" "100201"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.135 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&) "\x10\x02\x01"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.135 : bool ActivityFetchOperation::saveSamples() Start sample time QDateTime(2025-04-12 19:08:00.000 CEST Qt::TimeZone Europe/Prague )
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.149 : virtual bool ActivityFetchOperation::processBufferedData() Last sample time saved as  "so dub 12 19:15:00 2025" 7200 1744478100000
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.160 : virtual bool ActivityFetchOperation::processBufferedData() Last record was  QDateTime(2025-04-12 19:15:00.000 CEST Qt::LocalTime)
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.160 : Sending Ack
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.161 : bool AbstractFetchOperation::sendAck()
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.161 : Writing to  "00000004-0000-3512-2118-0009af100700" : "0309"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.161 : void QBLECharacteristic::writeValue(const QByteArray&) const "0309"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.229 : void MiBandService::characteristicChanged(const QString&, const QByteArray&) Changed: "00000004-0000-3512-2118-0009af100700" "100301"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.230 : virtual bool AbstractFetchOperation::handleMetaData(const QByteArray&) "\x10\x03\x01"
May 23 11:42:06 ubuntu-phablet harbour-amazfishd[5632]: 2025-05-23 11:42:06.230 : Got reply to COMMAND_ACK_ACTIVITY_DATA
```