### PR TITLE
Compute scale of steps according to max value

### DIFF
--- a/ui/qml/components/GraphData.qml
+++ b/ui/qml/components/GraphData.qml
@@ -51,6 +51,7 @@ Item {
 
     property real minY: 0 //Always 0
     property real maxY: 0
+    property real suggestedMaxY: 0
 
     property int minX: 0
     property int maxX: 0
@@ -75,8 +76,10 @@ Item {
             }
         });
         points = data;
+
+        suggestedMaxY = pointMaxY * 1.20
         if (scale) {
-            maxY = pointMaxY * 1.20;
+            maxY = suggestedMaxY;
         }
         doubleAxisXLables = ((maxX - minX) > 129600); // 1,5 days
 

--- a/ui/qml/pages/StepsPage.qml
+++ b/ui/qml/pages/StepsPage.qml
@@ -25,7 +25,7 @@ PagePL {
             font.pixelSize: styler.themeFontSizeExtraLarge * 3
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width
-            text: _InfoSteps > 0 ? _InfoSteps.toLocaleString() : graphStepSummary.lastValue.toLocaleString()
+            text: graphStepSummary.lastValue.toLocaleString()
             horizontalAlignment: Text.AlignHCenter
         }
 
@@ -57,7 +57,10 @@ PagePL {
             graphType: 2
 
             minY: 0
-            maxY: 2 * AmazfishConfig.profileFitnessGoal
+            maxY: (2 * AmazfishConfig.profileFitnessGoal > suggestedMaxY)
+                  ? 2 * AmazfishConfig.profileFitnessGoal
+                  : Math.ceil(suggestedMaxY/1000)*1000
+
             valueConverter: function(value) {
                 return value.toFixed(0);
             }


### PR DESCRIPTION
Fixes: #513

This patch suggests using a computed maxY scale, rounded up to the nearest 1000.