### PR TITLE
Different version for ubuntu touch focal and noble

### DIFF
--- a/click/manifest.json.in
+++ b/click/manifest.json.in
@@ -9,7 +9,7 @@
             "desktop":  "harbour-amazfish-ui.desktop"
         }
     },
-    "version": "2.7.0",
+    "version": "2.7.0-@CLICK_FRAMEWORK_BASE@",
     "maintainer": "Adam Pigg <adam@piggz.co.uk>",
     "framework" : "@CLICK_FRAMEWORK@"
 }

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 8.5.0
+clickable_minimum_required: 8.5.1
 
 prebuild: git submodule update --init
 kill: harbour-amazfish


### PR DESCRIPTION
The version for ubuntu touch 20.04/focal requires different version than for 24.04/noble, recently merged clickable patch https://gitlab.com/clickable/clickable/-/merge_requests/686 should solve this without much pain.

This is draft since new version of clickable wasn't tagged.