### PR TITLE
Fixing setTime for older ZeppOS devices

### DIFF
--- a/daemon/src/devices/zeppos/zepposuserinfoservice.cpp
+++ b/daemon/src/devices/zeppos/zepposuserinfoservice.cpp
@@ -9,7 +9,7 @@ ZeppOsUserInfoService::ZeppOsUserInfoService(ZeppOSDevice *device) : AbstractZep
 
 QString ZeppOsUserInfoService::name() const
 {
-    return "time";
+    return "userinfo";
 }
 
 void ZeppOsUserInfoService::handlePayload(const QByteArray &payload)

--- a/daemon/src/devices/zepposdevice.cpp
+++ b/daemon/src/devices/zepposdevice.cpp
@@ -184,8 +184,15 @@ void ZeppOSDevice::authenticated(bool ready)
 void ZeppOSDevice::ready()
 {
     setConnectionState("authenticated");
+    if (m_supportedServices.end() != m_supportedServices.find(m_timeService->endpoint())) {
+        m_timeService->setTime();
+    } else {
+        MiBandService *mi = qobject_cast<MiBandService*>(service(MiBandService::UUID_SERVICE_MIBAND));
+        if (mi) {
+            mi->setCurrentTime();
+        }
+    }
 
-    m_timeService->setTime();
     m_stepsService->enableRealtimeSteps(true);
 }
 


### PR DESCRIPTION
Time services is not enumerated on GTR3 Pro, so the old MiBandService method needs to be used (and looks working)