### PR TITLE
Use DialogListPL for Settings-huami-shortcuts

### DIFF
--- a/ui/qml/pages/Settings-huami-shortcuts.qml
+++ b/ui/qml/pages/Settings-huami-shortcuts.qml
@@ -5,7 +5,7 @@ import QtQml.Models 2.1
 import "../components"
 import "../components/platform"
 
-PagePL {
+DialogListPL {
     id: page
     title: qsTr("Huami Display Items")
 
@@ -13,64 +13,45 @@ PagePL {
         id: displayItems
     }
 
-    Column
-    {
-        id: column
+    acceptText: qsTr("Save Settings")
+    onAccepted: {
+        saveDisplayItems();
+        saveSettings();
+    }
+
+    model: displayItems
+    delegate: DraggableItem {
         width: parent.width
-        anchors.top: parent.top
-        anchors.margins: styler.themePaddingMedium
-        spacing: styler.themePaddingLarge
-
-        ListView {
-            id: view
+        Item {
+            height: textSwitch.height * 1.5
             width: parent.width
-            height: page.height * 0.6
-            model: displayItems
-            spacing: 4
-            cacheBuffer: 50
-            clip: true
-            delegate: DraggableItem {
-                Item {
-                    height: textSwitch.height * 1.5
-                    width: view.width
 
-                    TextSwitchPL {
-                        id: textSwitch
-                        text: itemText
-                        checked: itemVisible
-                        width: parent.width / 2
-                        y: (parent.height - height) / 2
-                        onCheckedChanged: {
-                            itemVisible = checked;
-                        }
-                    }
-                }
-                draggedItemParent: page
-                onMoveItemRequested: {
-                    displayItems.move(from, to, 1);
+            TextSwitchPL {
+                id: textSwitch
+                text: itemText
+                checked: itemVisible
+                width: parent.width / 2
+                y: (parent.height - height) / 2
+                onCheckedChanged: {
+                    itemVisible = checked;
                 }
             }
         }
-
-        ButtonPL {
-            anchors.horizontalCenter: parent.horizontalCenter
-            text: qsTr("Save Settings")
-            onClicked: {
-                saveDisplayItems();
-                saveSettings();
-            }
+        draggedItemParent: parent
+        onMoveItemRequested: {
+            displayItems.move(from, to, 1);
         }
+    }
 
-        Timer {
-            //Allow data to sync
-            id: tmrSetDelay
-            repeat: false
-            interval: 500
-            running: false
-            onTriggered: {
-                DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_DEVICE_DISPLAY_ITEMS);
-                app.pages.pop();
-            }
+    Timer {
+        //Allow data to sync
+        id: tmrSetDelay
+        repeat: false
+        interval: 500
+        running: false
+        onTriggered: {
+            DaemonInterfaceInstance.applyDeviceSetting(Amazfish.SETTING_DEVICE_DISPLAY_ITEMS);
+            app.pages.pop();
         }
     }
 


### PR DESCRIPTION
Current implementation is using ListView with height: 0.6* page.height. It looks ugly when list contain more items

https://github.com/piggz/harbour-amazfish/blob/604c4437000c796c6ca45d289909b0c85bb942b1/ui/qml/pages/Settings-huami-shortcuts.qml#L27

<img width="250" alt="Screenshot at 2025-11-29 08-22-36" src="https://github.com/user-attachments/assets/db0d9e2b-83d3-45c0-95c3-b6b1a8eede01" />
<img width="250" alt="Screenshot at 2025-11-29 08-21-51" src="https://github.com/user-attachments/assets/257751b6-27fc-41e2-9da4-d05969e16dda" />


Need to check if everyting including drag and drop works on all platforms:
- [x] kirigami
- [x] sailfish os
- [x] ubuntu touch

<img width="240" alt="huiami-items" src="https://github.com/user-attachments/assets/e8de7323-b92b-435e-8421-18034979e891" />
