### PR TITLE
display steps and goal better centered

### DIFF
--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -187,18 +187,28 @@ PagePL {
 
                 LabelPL {
                     id: lblSteps
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors {
+                        horizontalCenter: parent.horizontalCenter
+                        bottom: centerItem.top
+                    }
                     color: styler.themeHighlightColor
                     font.pixelSize: styler.themeFontSizeExtraLarge
                     verticalAlignment: Text.AlignVCenter
                     text: _InfoSteps.toLocaleString()
                 }
 
+                Item {
+                    id: centerItem
+                    width: 1
+                    height: 1
+                    anchors.centerIn: parent
+                }
+
                 LabelPL {
                     id: lblGoal
                     anchors {
                         horizontalCenter: parent.horizontalCenter
-                        top: lblSteps.bottom
+                        top: centerItem.bottom
                         topMargin: styler.themePaddingSmall
                     }
                     color: styler.themeSecondaryHighlightColor


### PR DESCRIPTION
Currently the steps and the goal are not properly centered in the circle. This PR will improve that.

Before:

<img width="1080" height="2160" alt="grafik" src="https://github.com/user-attachments/assets/d9f8d1a2-550d-4d78-84ee-36fed315ca11" />

After:

<img width="1080" height="2160" alt="grafik" src="https://github.com/user-attachments/assets/28356f29-db37-416e-9ff6-836ccb732c11" />
