### PR TITLE
unsupported file transfer probably doesn't have valid handlePayload function

### DIFF
--- a/daemon/src/devices/huami/zeppos/zepposfiletransferservice.cpp
+++ b/daemon/src/devices/huami/zeppos/zepposfiletransferservice.cpp
@@ -22,6 +22,7 @@ void ZeppOsFileTransferService::handlePayload(const QByteArray &payload)
     int version = payload[1] & 0xff;
     if (version == 1 || version == 2) {
         qDebug() << "Unsupported file transfer service version: " << version;
+        return;
     } else if (version == 3) {
         m_impl = new ZeppOsFileTransferV3(this, m_device);
     } else {


### PR DESCRIPTION
The m_impl is probably undefined and causes segfault
```
#0  0x0000005555622e4c in ZeppOsFileTransferService::handlePayload(QByteArray const&) ()
#1  0x000000555560c864 in Huami2021ChunkedDecoder::decode(QByteArray) ()
#2  0x000000555569575c in MiBandService::handleChunked(QByteArray) ()
#3  0x0000005555695988 in MiBandService::characteristicChanged(QString const&, QByteArray const&) ()
#4  0x0000007fb7c105cc in ?? () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#5  0x000000555558c7f8 in QBLEService::characteristicChanged(QString const&, QByteArray const&) ()
#6  0x0000007fb7c105cc in ?? () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#7  0x000000555558c538 in QBLECharacteristic::characteristicChanged(QString const&, QByteArray const&) ()
#8  0x00000055556d1c18 in QBLECharacteristic::onPropertiesChanged(QString const&, QMap<QString, QVariant> const&, QStringList const&) ()
#9  0x0000005555597370 in QBLECharacteristic::qt_metacall(QMetaObject::Call, int, void**) ()
#10 0x0000007fb6b4685c in ?? () from /lib/aarch64-linux-gnu/libQt5DBus.so.5
#11 0x0000007fb7c02b00 in QObject::event(QEvent*) () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#12 0x0000007fb7bcc454 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#13 0x0000007fb7bd0340 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#14 0x0000007fb7c3880c in ?? () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#15 0x0000007fb5c4088c in ?? () from /lib/aarch64-linux-gnu/libglib-2.0.so.0
#16 0x0000007fb5ca3818 in ?? () from /lib/aarch64-linux-gnu/libglib-2.0.so.0
#17 0x0000007fb5c3fb48 in g_main_context_iteration () from /lib/aarch64-linux-gnu/libglib-2.0.so.0
#18 0x0000007fb7c37c8c in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#19 0x0000007fb7bca634 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#20 0x0000007fb7bd45b0 in QCoreApplication::exec() () from /lib/aarch64-linux-gnu/libQt5Core.so.5
#21 0x0000005555585af8 in main ()
```