### PR TITLE
Fixes segfault caused by missing clear in reset() in triggerNextOperation()

### DIFF
--- a/daemon/src/devices/huami/huamifetcher.cpp
+++ b/daemon/src/devices/huami/huamifetcher.cpp
@@ -105,6 +105,7 @@ void HuamiFetcher::reset()
         m_device->message(tr("All operations cancelled"));
     }
     qDeleteAll(m_operations);
+    m_operations.clear();
     delete m_currentOperation;
     m_currentOperation = nullptr;
     m_operationTimeout->stop();


### PR DESCRIPTION
The segfault was reported in #601; this change does not fix the issue itself.

I’m not able to verify whether this fix helps. @pemekcz, could you please test it?

RPM files should be available for download in the artifacts: https://github.com/piggz/harbour-amazfish/pull/603/checks

According to the example at https://doc.qt.io/qt-6/qtalgorithms.html#qDeleteAll, `qDeleteAll` is followed by `clear()`. I believe this is the correct way to use it. I just don’t know how to verify the scenario in which the issue was reported.