### PR TITLE
Print features to yaml

### DIFF
--- a/daemon/src/devicefactory.cpp
+++ b/daemon/src/devicefactory.cpp
@@ -14,6 +14,11 @@
 #include "dk08device.h"
 
 #include <functional>
+#include <QMetaEnum>
+#include <QTextStream>
+#include <QFile>
+#include <QRegularExpression>
+#include <QDebug>
 
 using DeviceCreator = std::function<AbstractDevice*(const QString &)>;
 
@@ -51,4 +56,75 @@ AbstractDevice* DeviceFactory::createDevice(const QString &deviceName, const QSt
 
     qWarning() << "DeviceCreator not found";
     return nullptr;
+}
+
+void DeviceFactory::printAvailableFeatures()
+{
+    for (auto it = deviceMap.begin(); it != deviceMap.end(); ++it) {
+        QString type = it.key();
+
+        // Create CamelCase filename from device name
+        QString fileName;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // Qt 5
+        QStringList parts = type.split(QRegExp("[\\s\\.\\-\\/]+"), QString::SkipEmptyParts);
+#else // Qt 6+
+        QStringList parts = type.split(QRegularExpression("[\\s\\.\\-\\/]+"), Qt::SkipEmptyParts);
+#endif
+        for (const QString &part : parts) {
+            fileName += part.at(0).toUpper() + part.mid(1);
+        }
+        fileName += ".md";
+
+        QFile file(fileName);
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            qWarning() << "Could not open file for writing:" << fileName;
+            continue;
+        }
+
+        QTextStream out(&file);
+        AbstractDevice* dev = it.value()(it.key());
+        if (dev) {
+            out << "---\n";
+            out << "title: \"" << type << "\"\n";
+            out << "image:\n";
+            out << "link:\n";
+            out << "support:\n";
+            out << "features:" << "\n";
+            Amazfish::Features supportedFeatures = dev->supportedFeatures();
+            QMetaEnum featureEnum = QMetaEnum::fromType<Amazfish::Feature>();
+            for (int i = 0; i < featureEnum.keyCount(); ++i) {
+                int val = featureEnum.value(i);
+                if (val == 0) {
+                    continue; // Skip FEATURE_NONE
+                }
+                out << "  - id: \"" << featureEnum.key(i) << "\"" << "\n";
+                if (supportedFeatures & static_cast<Amazfish::Feature>(val)) {
+                    out << "    value: \"Y\"" << "\n";
+                } else {
+                    out << "    value: \"N\"" << "\n";
+                }
+            }
+
+            Amazfish::DataTypes supportedDataTypes = dev->supportedDataTypes();
+            QMetaEnum dataTypeEnum = QMetaEnum::fromType<Amazfish::DataType>();
+            for (int i = 0; i < dataTypeEnum.keyCount(); ++i) {
+                int val = dataTypeEnum.value(i);
+                if (val == 0) {
+                    continue; // Skip TYPE_NONE
+                }
+
+                out << "  - id: \"" << dataTypeEnum.key(i) << "\"" << "\n";
+                if (supportedDataTypes & static_cast<Amazfish::DataType>(val)) {
+                    out << "    value: \"Y\"" << "\n";
+                } else {
+                    out << "    value: \"N\"" << "\n";
+                }
+            }
+
+            delete dev;
+        }
+        out << "---\n";
+        file.close();
+        qDebug() << "Exported features for" << type << "to" << fileName;
+    }
 }

--- a/daemon/src/devicefactory.h
+++ b/daemon/src/devicefactory.h
@@ -8,6 +8,7 @@ class DeviceFactory
 {
 public:
     static AbstractDevice* createDevice(const QString &deviceName, const QString &deviceType);
+    static void printAvailableFeatures();
 };
 
 #endif

--- a/daemon/src/harbour-amazfish-daemon.cpp
+++ b/daemon/src/harbour-amazfish-daemon.cpp
@@ -18,6 +18,7 @@
 #include <QDir>
 
 #include "deviceinterface.h"
+#include "devicefactory.h"
 
 static void daemonize();
 static void signalHandler(int sig);
@@ -39,6 +40,11 @@ int main(int argc, char **argv)
     QCoreApplication app(argc, argv);
     QCoreApplication::setOrganizationName("harbour-amazfish");
     QCoreApplication::setApplicationName("harbour-amazfish");
+
+    if (app.arguments().contains("--features")) {
+        DeviceFactory::printAvailableFeatures();
+        return 0;
+    }
 
     {
         QString tr_path(TRANSLATION_FOLDER);


### PR DESCRIPTION
This should simplify updates of documentation.
Some bits are still missing.
For example N/A means device doesn't provide feature. This isn't considered in daemon at all.
The image and huami pairing code is available only in qml model. Those lists are redundant which is ugly and may lead to inconsistency. 

Example of outuput:
```
---
title: Amazfit Neo
image: 
link: 
support: 
features:
  - id: "FEATURE_HRM"
    value: "Y"
  - id: "FEATURE_WEATHER"
    value: "Y"
  - id: "FEATURE_ACTIVITY"
    value: "Y"
  - id: "FEATURE_STEPS"
    value: "Y"
  - id: "FEATURE_ALARMS"
    value: "Y"
  - id: "FEATURE_ALERT"
    value: "Y"
  - id: "FEATURE_EVENT_REMINDER"
    value: "N"
  - id: "FEATURE_MUSIC_CONTROL"
    value: "N"
  - id: "FEATURE_BUTTON_ACTION"
    value: "N"
  - id: "FEATURE_SCREENSHOT"
    value: "N"
  - id: "FEATURE_FILE_INSTALL"
    value: "N"
  - id: "TYPE_DEBUGLOG"
    value: "N"
  - id: "TYPE_ACTIVITY"
    value: "Y"
  - id: "TYPE_GPS_TRACK"
    value: "N"
  - id: "TYPE_STRESS"
    value: "N"
  - id: "TYPE_SPO2"
    value: "N"
  - id: "TYPE_PAI"
    value: "N"
  - id: "TYPE_HEART_RATE"
    value: "Y"
  - id: "TYPE_SLEEP_RESPIRATORY_RATE"
    value: "N"
  - id: "TYPE_TEMPERATURE"
    value: "N"
  - id: "TYPE_SLEEP"
    value: "N"
  - id: "TYPE_HUAMI_STATISTICS"
    value: "N"
  - id: "TYPE_HRV"
    value: "N"
---
```

I was trying to find which features aren't covered, I suggest to add feature settings to code or dropping it from documentation:
- pairing              - pairing must work for all devices  -> DROP
- calls                - FEATURE_CALLS
- settings             - we should introduce supportedSettings() function.
- watchface_upload     - FEATURE_FILE_INSTALL (and update description)
- navigation           - FEATURE_NAVIGATION
- battery_status       - FEATURE_BATTERY
- sync_time            - FEATURE_TIME_SYNC
- find_my_phone        - FEATURE_FIND_MY_PHONE
