### PR TITLE
Dismiss notifications

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -216,6 +216,20 @@ void DeviceInterface::onNotification(watchfish::Notification *notification)
 }
 
 void DeviceInterface::onNotificationClosed(quint32 nid, quint32 reason) {
+    qDebug() << Q_FUNC_INFO << nid << reason <<  m_notificationBuffer.count();
+
+    // remove closed notifications from buffer
+    if (!m_notificationBuffer.isEmpty()) {
+        auto it = m_notificationBuffer.begin();
+        while (it != m_notificationBuffer.end()) {
+            if (it->id == static_cast<int>(nid)) {
+                it = m_notificationBuffer.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
     if (m_device && m_device->connectionState() == "authenticated" && m_device->supportsFeature(Amazfish::Feature::FEATURE_ALERT)){
         m_device->sendAlertClosed(nid, reason);
     }

--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -43,6 +43,7 @@ DeviceInterface::DeviceInterface()
         connect(m_device, &AbstractDevice::buttonPressed, this, &DeviceInterface::handleButtonPressed, Qt::UniqueConnection);
         connect(m_device, &AbstractDevice::informationChanged, this, &DeviceInterface::slot_informationChanged, Qt::UniqueConnection);
         connect(m_device, &AbstractDevice::deviceEvent, this, &DeviceInterface::deviceEvent, Qt::UniqueConnection);
+        connect(m_device, &AbstractDevice::dismissNotification, this, &DeviceInterface::dismissNotification, Qt::UniqueConnection);
     }
 
     //Create the DBUS HRM Interface
@@ -52,6 +53,7 @@ DeviceInterface::DeviceInterface()
 
     //Notifications
     connect(&m_notificationMonitor, &watchfish::NotificationMonitor::notification, this, &DeviceInterface::onNotification);
+    connect(&m_notificationMonitor, &watchfish::NotificationMonitor::notificationClosed, this, &DeviceInterface::onNotificationClosed);
 
     // Calls
 #if defined(MER_EDITION_SAILFISH) || defined(UUITK_EDITION)
@@ -212,6 +214,13 @@ void DeviceInterface::onNotification(watchfish::Notification *notification)
         }
     }
 }
+
+void DeviceInterface::onNotificationClosed(quint32 nid, quint32 reason) {
+    if (m_device && m_device->connectionState() == "authenticated" && m_device->supportsFeature(Amazfish::Feature::FEATURE_ALERT)){
+        m_device->sendAlertClosed(nid, reason);
+    }
+}
+
 
 void DeviceInterface::onRingingChanged()
 {
@@ -778,6 +787,14 @@ void DeviceInterface::musicChanged()
             m_device->setMusicStatus(m_musicController.status() == watchfish::MusicController::StatusPlaying,
                 m_musicController.title(), m_musicController.artist(), m_musicController.album());
         }
+    }
+}
+
+void DeviceInterface::dismissNotification(quint32 id) {
+    qDebug() << Q_FUNC_INFO << id;
+    watchfish::Notification *n  = m_notificationMonitor.getNotification(id);
+    if (n) {
+        n->close();
     }
 }
 

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -119,11 +119,13 @@ private:
     HRMService *hrmService() const;
     
     Q_SLOT void onNotification(watchfish::Notification *notification);
+    Q_SLOT void onNotificationClosed(quint32 nid, quint32 reason);
     Q_SLOT void onRingingChanged();
     Q_SLOT void onConnectionStateChanged();
     Q_SLOT void slot_informationChanged(Amazfish::Info infokey, const QString &infovalue);
     Q_SLOT void musicChanged();
     Q_SLOT void deviceEvent(AbstractDevice::Event event);
+    Q_SLOT void dismissNotification(quint32 id);
     Q_SLOT void handleButtonPressed(int presses);
     Q_SLOT void onEventTimer();
     Q_SLOT void backgroundActivityStateChanged();

--- a/daemon/src/devices/abstractdevice.cpp
+++ b/daemon/src/devices/abstractdevice.cpp
@@ -143,6 +143,16 @@ void AbstractDevice::fetchData(Amazfish::DataTypes dataTypes)
 {
 }
 
+void AbstractDevice::sendAlert(const Amazfish::WatchNotification &notification) {
+    Q_UNUSED(notification)
+}
+
+void AbstractDevice::sendAlertClosed(quint32 nid, quint32 reason) {
+    Q_UNUSED(nid)
+    Q_UNUSED(reason)
+}
+
+
 void AbstractDevice::sendWeather(CurrentWeather *weather)
 {
     Q_UNUSED(weather);

--- a/daemon/src/devices/abstractdevice.h
+++ b/daemon/src/devices/abstractdevice.h
@@ -75,7 +75,8 @@ public:
     virtual QString information(Amazfish::Info i) const;
     virtual void applyDeviceSetting(Amazfish::Settings s);
     virtual void rebootWatch();
-    virtual void sendAlert(const Amazfish::WatchNotification &notification) = 0;
+    virtual void sendAlert(const Amazfish::WatchNotification &notification);
+    virtual void sendAlertClosed(quint32 nid, quint32 reason);
     virtual void incomingCall(const QString &caller) = 0;
     virtual void incomingCallEnded() = 0;
     virtual void syncCalendar(QList<watchfish::CalendarEvent> &eventlist);
@@ -101,6 +102,7 @@ public:
     Q_SIGNAL void connectionStateChanged();
     Q_SIGNAL void informationChanged(Amazfish::Info key, const QString& val);
     Q_SIGNAL void deviceEvent(Event event);
+    Q_SIGNAL void dismissNotification(quint32 id);
 
 protected:
     bool m_needsAuth = false;

--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -131,6 +131,21 @@ void BangleJSDevice::sendAlert(const Amazfish::WatchNotification &notification)
     uart->txJson(o);
 }
 
+
+void BangleJSDevice::sendAlertClosed(quint32 nid, quint32 reason) {
+    Q_UNUSED(reason)
+
+    UARTService *uart = qobject_cast<UARTService*>(service(UARTService::UUID_SERVICE_UART));
+    if (!uart){
+        return;
+    }
+    QJsonObject o;
+    o.insert("t", "notify-");
+    o.insert("id", static_cast<qint64>(nid));
+    uart->txJson(o);
+}
+
+
 void BangleJSDevice::incomingCall(const QString &caller)
 {
     qDebug() << Q_FUNC_INFO;
@@ -566,13 +581,13 @@ void BangleJSDevice::handleRxJson(const QJsonObject &json)
 
     } else if (t == "force_calendar_sync") {
 
-	QList<int> deviceIds;
-	const QJsonArray ids = json.value("ids").toArray();
-	for (const QJsonValue &v : ids) {
-	    deviceIds.append(v.toInt());
-	}
-	qDebug() << "Calendar IDs from device:" << deviceIds;
-	syncCalendarWithDeviceIds(deviceIds);
+    QList<int> deviceIds;
+    const QJsonArray ids = json.value("ids").toArray();
+    for (const QJsonValue &v : ids) {
+        deviceIds.append(v.toInt());
+    }
+    qDebug() << "Calendar IDs from device:" << deviceIds;
+    syncCalendarWithDeviceIds(deviceIds);
 
     } else if (t == "music") {
         QString music_action = json.value("n").toString();
@@ -596,7 +611,13 @@ void BangleJSDevice::handleRxJson(const QJsonObject &json)
 //            emit deviceEvent(AbstractDevice::EVENT_APP_MUSIC);
 
 //    } else if (t == "call") {
-//    } else if (t == "notify") {
+   } else if (t == "notify") {
+        qDebug() << "notify" << json.value("n");
+       // "id":56,"n":"DISMISS","t":"notify"
+       if (json.value("n").toString() == "DISMISS") {
+           emit dismissNotification(json.value("id").toInt());
+       }
+
     } else if (t == "actfetch") {
         int sample_count = json.value("count").toInt();
         QString fetch_state = json.value("state").toString();
@@ -1176,7 +1197,7 @@ void BangleJSDevice::forceCalendarSync()
     qDebug() << Q_FUNC_INFO;
     UARTService *uart = qobject_cast<UARTService*>(service(UARTService::UUID_SERVICE_UART));
     if (!uart) {
-	return;
+    return;
     }
 
     QJsonObject o;
@@ -1213,6 +1234,7 @@ void BangleJSDevice::syncCalendarWithDeviceIds(QList<int> &deviceIds) {
         m_event_id_map.clear();
         setOperationRunning(false);
         return;
+
     }
 
     // Step 1: Device has IDs we have no record of (e.g. after app restart) — remove them
@@ -1281,8 +1303,8 @@ void BangleJSDevice::sendCalendarEvent(int id, const watchfish::CalendarEvent &e
 
     QJsonObject o;
     // {t:"calendar", id:int, type:int, timestamp:seconds, durationInSeconds, title:string, description:string, location:string, calName:string, color:int, allDay:bool
-	// type:int, what is it?
-	// color:int e.g. 0xff0000
+    // type:int, what is it?
+    // color:int e.g. 0xff0000
 
     QString description = event.description();
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) // Qt 5

--- a/daemon/src/devices/banglejsdevice.h
+++ b/daemon/src/devices/banglejsdevice.h
@@ -66,6 +66,8 @@ public:
     void abortOperations() override;
 
     void sendAlert(const Amazfish::WatchNotification &notification) override;
+    void sendAlertClosed(quint32 nid, quint32 reason) override;
+
     void incomingCall(const QString &caller) override;
     void incomingCallEnded() override;
 


### PR DESCRIPTION
Depends on https://github.com/piggz/libwatchfish/pull/24

https://www.youtube.com/watch?v=r5ryeAIv7R8

Now it looks working, but I am not sure about notificationClose behaviour. On ubuntu touch is notificationClose streamed when popup disappear, but notification is still visible in notification screen.

For ubuntu touch it might be good to implement support for `com.lomiri.Postal` dbus service similar as rockwork does.

I am not sure how SailfishOS behaves.