### PR TITLE
[Bangle.js] emit last known battery information on refreshInformation()

### DIFF
--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -486,6 +486,8 @@ void BangleJSDevice::refreshInformation()
     BatteryService *bat = qobject_cast<BatteryService*>(service(BatteryService::UUID_SERVICE_BATTERY));
     if (bat) {
         bat->refreshInformation();
+    } else {
+        emit informationChanged(Amazfish::Info::INFO_BATTERY, QString::number(m_infoBatteryLevel));
     }
 
 


### PR DESCRIPTION
On some compatible devices (e.g. T-Watch) there is battery service which can provide up to date information.

On Bangle.js with GadgetBridge, the battery status isn't usually transmitted on demand, but only when changed. The information is handled via last value. The refreshInformation() should provide last value when battery service isn't available. In future there might be fix which transmit command to get current battery level from device (it might be javascript which prints output compatible with GadgetBridge. For now this seems to be good enough