### PR TITLE
[Bangle.js] music exposes playpause command

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -753,6 +753,9 @@ void DeviceInterface::deviceEvent(AbstractDevice::Event event)
     case AbstractDevice::EVENT_MUSIC_PAUSE:
         m_musicController.pause();
         break;
+    case AbstractDevice::EVENT_MUSIC_PLAYPAUSE:
+        m_musicController.playPause();
+        break;
     case AbstractDevice::EVENT_MUSIC_NEXT:
         m_musicController.next();
         break;

--- a/daemon/src/devices/abstractdevice.h
+++ b/daemon/src/devices/abstractdevice.h
@@ -25,6 +25,7 @@ public:
         EVENT_MUSIC_STOP,
         EVENT_MUSIC_PLAY,
         EVENT_MUSIC_PAUSE,
+        EVENT_MUSIC_PLAYPAUSE,
         EVENT_MUSIC_NEXT,
         EVENT_MUSIC_PREV,
         EVENT_MUSIC_VOLUP,

--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -581,6 +581,8 @@ void BangleJSDevice::handleRxJson(const QJsonObject &json)
             emit deviceEvent(AbstractDevice::EVENT_MUSIC_PLAY);
         } else if (music_action == "pause") {
             emit deviceEvent(AbstractDevice::EVENT_MUSIC_PAUSE);
+        } else if (music_action == "playpause") {
+            emit deviceEvent(AbstractDevice::EVENT_MUSIC_PLAYPAUSE);
         } else if (music_action == "next") {
             emit deviceEvent(AbstractDevice::EVENT_MUSIC_NEXT);
         } else if (music_action == "previous") {


### PR DESCRIPTION
one command is used both actions
AmberMpris exposes directly playPause() function. I think it is easier to use that function directly instead of adding "playing" variable which might not represent actual status of player.