### PR TITLE
hide map when no coord is present and elide label column

### DIFF
--- a/ui/qml/pages/SportPage.qml
+++ b/ui/qml/pages/SportPage.qml
@@ -192,6 +192,7 @@ PagePL {
                     anchors.left: parent.left
                     anchors.leftMargin: styler.themePaddingMedium
                     text: T.translateSportKey(key)
+                    truncMode: truncModes.elide
                 }
 
                 LabelPL {
@@ -226,7 +227,7 @@ PagePL {
             accessToken: "pk.eyJ1IjoiamRyZXNjaGVyIiwiYSI6ImNqYmVta256YTJsdjUzMm1yOXU0cmxibGoifQ.JiMiONJkWdr0mVIjajIFZQ"
             cacheDatabaseDefaultPath: true
             styleUrl: "mapbox://styles/mapbox/outdoors-v11"
-            visible: true
+            visible: positionString(location[0], location[1], location[2]) === "---" ? false : true
 
             Item {
                 id: centerButton


### PR DESCRIPTION
I think it makes no sense to display the map when e.g. an indoor sport has no coordinate available. So hide it.

Also the left column texts can be quite long when translated. So better elide them to avoid overlapping to the second column.