### PR TITLE
ComboboxPL { property bool ifForm }

### DIFF
--- a/ui/qml/components/platform.qtcontrols/ComboBoxPL.qml
+++ b/ui/qml/components/platform.qtcontrols/ComboBoxPL.qml
@@ -27,6 +27,7 @@ Item {
     anchors.rightMargin: styler.themeHorizontalPageMargin
     height: Math.max(lab.height, val.height) + desc.height + desc.anchors.topMargin
 
+    property bool   inForm
     property int   currentIndex
     property alias description: desc.text
     property alias model: val.model

--- a/ui/qml/components/platform.qtcontrols/ComboBoxPL.qml
+++ b/ui/qml/components/platform.qtcontrols/ComboBoxPL.qml
@@ -21,13 +21,15 @@ import QtQuick.Controls 2.2
 
 Item {
     id: item
-    anchors.left: parent.left
-    anchors.leftMargin: styler.themeHorizontalPageMargin
-    anchors.right: parent.right
-    anchors.rightMargin: styler.themeHorizontalPageMargin
-    height: Math.max(lab.height, val.height) + desc.height + desc.anchors.topMargin
 
-    property bool   inForm
+    anchors.left: inForm ? undefined : parent.left
+    anchors.leftMargin: inForm ? undefined : styler.themeHorizontalPageMargin
+    anchors.right: inForm ? undefined : parent.right
+    anchors.rightMargin: inForm ? undefined : styler.themeHorizontalPageMargin
+    implicitHeight: (inForm ? val.height : Math.max(lab.height, val.height)) + desc.height + desc.anchors.topMargin
+
+    property bool   inForm: parent.isFormLayout ? true : false
+
     property int   currentIndex
     property alias description: desc.text
     property alias model: val.model

--- a/ui/qml/components/platform.silica/ComboBoxPL.qml
+++ b/ui/qml/components/platform.silica/ComboBoxPL.qml
@@ -22,6 +22,7 @@ import Sailfish.Silica 1.0
 ComboBox {
     id: box
     property string textRole: ""
+    property bool   inForm
 
     menu: ContextMenu {
         Repeater {

--- a/ui/qml/pages/DebugInfo.qml
+++ b/ui/qml/pages/DebugInfo.qml
@@ -194,7 +194,7 @@ PagePL {
         }
 
         Row {
-            width: parent.width
+            width: page.width
             spacing: styler.themePaddingLarge
             visible: supportsFeature(Amazfish.FEATURE_ALERT)
 


### PR DESCRIPTION
The inForm property was missing for ComboboxPL. The Combobox wasn't working at DebugPage in Ubuntu Touch. It was broken also for Sailfish OS.