### PR TITLE
Add option to filter out email app notifications to watch

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -178,6 +178,14 @@ HRMService *DeviceInterface::hrmService() const
 
 void DeviceInterface::onNotification(watchfish::Notification *notification)
 {
+    if ((AmazfishConfig::instance()->appEmailsNotification()) &&
+     (notification->appId() == "messageserver5" ||
+      notification->appName() == "Mail"))
+    {
+        qDebug() << "Ignoring Sailfish Mail notification";
+        return;
+    }
+
     Amazfish::WatchNotification n;
     n.id = notification->id();
     n.appId = notification->appId();

--- a/lib/src/amazfishconfig.h
+++ b/lib/src/amazfishconfig.h
@@ -128,6 +128,7 @@ public:
     BOOL_OPTION(QStringLiteral("app/autosyncdata"),     appAutoSyncData,     setAppAutoSyncData,     true)
     BOOL_OPTION(QStringLiteral("app/notifylowbattery"), appNotifyLowBattery, setAppNotifyLowBattery, true)
     BOOL_OPTION(QStringLiteral("app/overridefwcheck"),  appOverrideFwCheck,  setAppOverrideFwCheck,  false)
+    BOOL_OPTION(QStringLiteral("app/emailsnotification"),  appEmailsNotification,  setEmailsNotification,  false)
     BOOL_OPTION(QStringLiteral("app/navigationnotification"),  appNavigationNotification,  setAppNavigationNotification,  false)
     BOOL_OPTION(QStringLiteral("app/simulateevents"),  appSimulateEventSupport,  setSimulateEventSupport,  false)
     BOOL_OPTION(QStringLiteral("app/transliterate"),  appTransliterate,  setTransliterate,  false)

--- a/ui/qml/pages/Settings-app.qml
+++ b/ui/qml/pages/Settings-app.qml
@@ -111,6 +111,14 @@ PagePL {
         }
 
         TextSwitchPL {
+            id: chkEmailsNotification
+            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+
+            width: parent.width
+            text: qsTr("No notification for emails")
+        }
+
+        TextSwitchPL {
             id: chkNavigationNotification
             visible: supportsFeature(Amazfish.FEATURE_ALERT)
 
@@ -250,6 +258,7 @@ PagePL {
         sldCalendarRefresh.value = AmazfishConfig.appRefreshCalendar;
         chkAutoSyncData.checked = AmazfishConfig.appAutoSyncData;
         chkNotifyLowBattery.checked = AmazfishConfig.appNotifyLowBattery;
+        chkEmailsNotification.checked = AmazfishConfig.appEmailsNotification;
         chkNavigationNotification.checked = AmazfishConfig.appNavigationNotification;
         chkSimulateEventSupport.checked = AmazfishConfig.appSimulateEventSupport;
         chkTransliterate.checked = AmazfishConfig.appTransliterate;
@@ -265,6 +274,7 @@ PagePL {
         AmazfishConfig.appRefreshCalendar = sldCalendarRefresh.value;
         AmazfishConfig.appAutoSyncData = chkAutoSyncData.checked;
         AmazfishConfig.appNotifyLowBattery = chkNotifyLowBattery.checked;
+        AmazfishConfig.appEmailsNotification = chkEmailsNotification.checked;
         AmazfishConfig.appNavigationNotification = chkNavigationNotification.checked;
         AmazfishConfig.appSimulateEventSupport = chkSimulateEventSupport.checked;
         AmazfishConfig.localAdapter = cboLocalAdapter.value;


### PR DESCRIPTION
My watch was going crazy with notifications every time I checked my email with the stock SFOS Email app (I get a lot of emails), and there was no way to disable/filter the notifications on new emails anywhere. Several users also asked about this on the SFOS forum, but there was no solution. This patch adds an option to the Amazfish Application Settings menu "No notifications for emails" that does exactly that. Default is off, i.e. no change. No other side effects.

With the new option on (and saved!), notifications with appID "messageserver5" or appName "Mail" will be ignored and not sent to the watch. This covers exactly the notifications from the Mail app.