### PR TITLE
Fix base coordinate initialization in BipActivityDetailParser

### DIFF
--- a/daemon/src/devices/huami/bipactivitydetailparser.cpp
+++ b/daemon/src/devices/huami/bipactivitydetailparser.cpp
@@ -26,8 +26,8 @@ void BipActivityDetailParser::parse(const QByteArray &bytes)
 {
     qDebug() << Q_FUNC_INFO << bytes.toHex();
 
-    m_baseLongitude = m_summary.baseLongitude();
-    m_baseLatitude = m_summary.baseLatitude();
+    m_baseLongitude = m_summary.baseLongitude() * HUAMI_TO_DECIMAL_DEGREES_DIVISOR;
+    m_baseLatitude = m_summary.baseLatitude() * HUAMI_TO_DECIMAL_DEGREES_DIVISOR;
     m_baseAltitude = m_summary.baseAltitude();
     m_baseDate = m_summary.startTime();
 


### PR DESCRIPTION
At some point the base coordinates in summary have been changed from huami values to actual coordinates. As BipActivityDetailParser works with huami values, we need to convert the base coordinates back before starting the work