### PR TITLE
Enable sleep data on bip

### DIFF
--- a/daemon/src/devices/huami/bipdevice.cpp
+++ b/daemon/src/devices/huami/bipdevice.cpp
@@ -23,7 +23,10 @@ Amazfish::Features BipDevice::supportedFeatures() const
 
 Amazfish::DataTypes BipDevice::supportedDataTypes() const
 {
-    return Amazfish::DataType::TYPE_ACTIVITY | Amazfish::DataType::TYPE_GPS_TRACK | Amazfish::DataType::TYPE_HEART_RATE;
+    return Amazfish::DataType::TYPE_ACTIVITY
+        | Amazfish::DataType::TYPE_GPS_TRACK
+        | Amazfish::DataType::TYPE_HEART_RATE
+        | Amazfish::DataType::TYPE_SLEEP;
 }
 
 QString BipDevice::deviceType() const


### PR DESCRIPTION
Bip supports sleep data, but since it wasn't advertised the UI didn't show it