### PR TITLE
Make supportsDataType() available as DaemonInterface function 

### DIFF
--- a/daemon/src/deviceinterface.cpp
+++ b/daemon/src/deviceinterface.cpp
@@ -1338,6 +1338,11 @@ bool DeviceInterface::supportsFeature(int f){
     return (supportedFeatures() & f);
 }
 
+bool DeviceInterface::supportsDataType(int t) {
+    return (supportedDataTypes() & t);
+}
+
+
 int DeviceInterface::supportedFeatures()
 {
     if (m_device) {

--- a/daemon/src/deviceinterface.h
+++ b/daemon/src/deviceinterface.h
@@ -54,6 +54,7 @@ public:
     Q_INVOKABLE int connectionStateChangedCount() const;
     Q_INVOKABLE bool operationRunning();
     Q_INVOKABLE bool supportsFeature(int f);
+    Q_INVOKABLE bool supportsDataType(int t);
     Q_INVOKABLE int supportedFeatures();
     Q_INVOKABLE int supportedDataTypes();
 

--- a/ui/qml/cover/CoverPage.qml
+++ b/ui/qml/cover/CoverPage.qml
@@ -66,7 +66,7 @@ CoverBackground {
             spacing: Theme.paddingLarge
             width: childrenRect.width
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: supportsFeature(Amazfish.FEATURE_STEPS)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_STEPS)
 
             Image {
                 id: imgSteps
@@ -90,7 +90,7 @@ CoverBackground {
             spacing: Theme.paddingLarge
             width: childrenRect.width
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: supportsFeature(Amazfish.FEATURE_HRM)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_HRM)
 
             Image {
                 id: imgHeartrate
@@ -117,7 +117,7 @@ CoverBackground {
             iconSource: "image://theme/icon-m-refresh";
 
             onTriggered: {
-                if (supportsFeature(Amazfish.FEATURE_HRM)) {
+                if (DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_HRM)) {
                     DaemonInterfaceInstance.requestManualHeartrate();
                 }
             }

--- a/ui/qml/harbour-amazfish.qml
+++ b/ui/qml/harbour-amazfish.qml
@@ -216,16 +216,6 @@ ApplicationWindowPL
         popup.showMessage(msg)
     }
 
-    function supportsFeature(feature) {
-        console.log("Supports feature", feature, (_authenticated && !_authenticated) || ((DaemonInterfaceInstance.supportedFeatures() & feature) === feature));
-        return (_authenticated && !_authenticated) || ((DaemonInterfaceInstance.supportedFeatures() & feature) === feature)
-    }
-
-    function supportsData(data) {
-        console.log("Supports data:", data, (_authenticated && !_authenticated) || ((DaemonInterfaceInstance.supportedDataTypes() & data) === data))
-        return (_authenticated && !_authenticated) || ((DaemonInterfaceInstance.supportedDataTypes() & data) === data)
-    }
-
     function _refreshInformation() {
         if (!_authenticated) {
             return

--- a/ui/qml/pages/AnalysisPage.qml
+++ b/ui/qml/pages/AnalysisPage.qml
@@ -50,6 +50,7 @@ PagePL {
 
             axisY.units: qsTr("BPM")
             type: DataSource.Heartrate
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.TYPE_HEART_RATE)
 
             minY: 0
             maxY: 200
@@ -102,6 +103,8 @@ PagePL {
             axisY.units: ""
             type: DataSource.HRV
 
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_HRV)
+
             minY: 0
             maxY: 100
 
@@ -117,6 +120,8 @@ PagePL {
 
             axisY.units: "°C"
             axisX.mask: "hh:mm"
+
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_TEMPERATURE)
 
             type: DataSource.BodyTemperature
             graphType: line

--- a/ui/qml/pages/DebugInfo.qml
+++ b/ui/qml/pages/DebugInfo.qml
@@ -196,7 +196,7 @@ PagePL {
         Row {
             width: page.width
             spacing: styler.themePaddingLarge
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
 
 
             ListModel {
@@ -329,7 +329,7 @@ PagePL {
             text: qsTr("Request Screenshot")
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width * 0.8
-            visible: supportsFeature(Amazfish.FEATURE_SCREENSHOT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_SCREENSHOT)
             onClicked: {
                 DaemonInterfaceInstance.requestScreenshot();
             }
@@ -344,7 +344,7 @@ PagePL {
         }
         ButtonPL {
             text: qsTr("Send Weather")
-            visible: supportsFeature(Amazfish.FEATURE_WEATHER)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_WEATHER)
 
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width * 0.8
@@ -354,7 +354,7 @@ PagePL {
         }
         ButtonPL {
             text: qsTr("Update Calendar")
-            visible: supportsFeature(Amazfish.FEATURE_EVENT_REMINDER)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_EVENT_REMINDER)
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width * 0.8
             onClicked: {
@@ -367,7 +367,7 @@ PagePL {
 
         ButtonPL {
             text: qsTr("Music Control")
-            visible: supportsFeature(Amazfish.FEATURE_MUSIC_CONTROL)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_MUSIC_CONTROL)
             anchors.horizontalCenter: parent.horizontalCenter
             width: parent.width * 0.8
             onClicked: {

--- a/ui/qml/pages/FirstPage.qml
+++ b/ui/qml/pages/FirstPage.qml
@@ -160,7 +160,7 @@ PagePL {
         //========== Tiles ==========
 
         StepsTile {
-            visible: supportsFeature(Amazfish.FEATURE_STEPS)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_STEPS)
             Layout.rowSpan: 2
             Layout.columnSpan: 2
             stepCount: _InfoSteps
@@ -179,7 +179,7 @@ PagePL {
 
         Tile {
             text: qsTr("Sleep")
-            visible: supportsData(Amazfish.TYPE_SLEEP)
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_SLEEP)
 
 
             contentItem: Image {
@@ -196,7 +196,7 @@ PagePL {
 
         Tile {
             text: qsTr("Heartrate")
-            visible: supportsData(Amazfish.TYPE_HEART_RATE)
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_HEART_RATE)
 
             contentItem: Image {
                 source: "../page-icons/icon-page-heartrate.png"
@@ -232,7 +232,7 @@ PagePL {
 
         Tile {
             text: qsTr("Sports")
-            visible: supportsFeature(Amazfish.FEATURE_ACTIVITY)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ACTIVITY)
 
             contentItem: Image {
                 source: "../page-icons/icon-page-sport.png"
@@ -247,7 +247,7 @@ PagePL {
 
         PAITile {
             id: paiTile
-            visible: supportsData(Amazfish.TYPE_PAI)
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_PAI)
             Layout.rowSpan: 2
             Layout.columnSpan: 2
 
@@ -258,7 +258,7 @@ PagePL {
 
         Tile {
             text: qsTr("SpO₂")
-            visible: supportsData(Amazfish.TYPE_SPO2)
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_SPO2)
 
             contentItem: Image {
                 source: "../page-icons/icon-page-spo2.png"
@@ -273,7 +273,7 @@ PagePL {
 
         Tile {
             text: qsTr("Stress")
-            visible: supportsData(Amazfish.TYPE_STRESS)
+            visible: DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_STRESS)
 
             contentItem: Image {
                 source: "../page-icons/icon-page-stress.png"
@@ -325,7 +325,7 @@ PagePL {
 
         Tile {
             text: qsTr("Install File")
-            visible: _authenticated && supportsFeature(Amazfish.FEATURE_FILE_INSTALL)
+            visible: _authenticated && DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_FILE_INSTALL)
 
             contentItem: Image {
                 source: "../page-icons/icon-page-install.png"
@@ -370,7 +370,7 @@ PagePL {
     }
 
     function updatePAI() {
-        if (!supportsData(Amazfish.TYPE_PAI)) {
+        if (!DaemonInterfaceInstance.supportsDataType(Amazfish.TYPE_PAI)) {
             return;
         }
         paiTile.update();

--- a/ui/qml/pages/Settings-app.qml
+++ b/ui/qml/pages/Settings-app.qml
@@ -82,13 +82,13 @@ PagePL {
         }
 
         SectionHeaderPL {
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
             text: qsTr("Notifications")
         }
 
         TextSwitchPL {
             id: chkSilenceConnect
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
 
             width: parent.width
             text: qsTr("Set silent profile on connect")
@@ -96,7 +96,7 @@ PagePL {
 
         TextSwitchPL {
             id: chkNotifyConnect
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
 
             width: parent.width
             text: qsTr("Notify on connect")
@@ -104,7 +104,7 @@ PagePL {
 
         TextSwitchPL {
             id: chkNotifyLowBattery
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
 
             width: parent.width
             text: qsTr("Low battery notification")
@@ -112,7 +112,7 @@ PagePL {
 
         TextSwitchPL {
             id: chkNavigationNotification
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
 
             width: parent.width
             text: qsTr("Navigation notifications")
@@ -120,7 +120,7 @@ PagePL {
 
         TextSwitchPL {
             id: chkTransliterate
-            visible: supportsFeature(Amazfish.FEATURE_ALERT)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT)
 
             width: parent.width
             text: qsTr("Transliterate notifications")
@@ -128,7 +128,7 @@ PagePL {
 
         TextSwitchPL {
             id: chkSimulateEventSupport
-            visible: supportsFeature(Amazfish.FEATURE_ALERT) && !supportsFeature(Amazfish.FEATURE_EVENT_REMINDER)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALERT) && !DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_EVENT_REMINDER)
 
             width: parent.width
             text: qsTr("Simulate event reminder support")
@@ -146,7 +146,7 @@ PagePL {
 
         SliderPL {
             id: sldWeatherRefresh
-            visible: supportsFeature(Amazfish.FEATURE_WEATHER)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_WEATHER)
 
             width: parent.width
             minimumValue: 15
@@ -162,7 +162,7 @@ PagePL {
             maximumValue: 240
             stepSize: 15
             label: qsTr("Refresh calendar every (%1) minutes").arg(value)
-            visible: supportsFeature(Amazfish.FEATURE_EVENT_REMINDER)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_EVENT_REMINDER)
         }
 
         SectionHeaderPL {
@@ -224,7 +224,7 @@ PagePL {
         ButtonPL {
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Button Actions")
-            visible: supportsFeature(Amazfish.FEATURE_BUTTON_ACTION)
+            visible: DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_BUTTON_ACTION)
             onClicked: {
                 app.pages.push(Qt.resolvedUrl("Settings-button-action.qml"))
             }

--- a/ui/qml/pages/Settings-menu.qml
+++ b/ui/qml/pages/Settings-menu.qml
@@ -44,10 +44,10 @@ PageListPL {
 
         function checkFeature() {
             if(name === qsTr("Alarms")) {
-                return supportsFeature(Amazfish.FEATURE_ALARMS)
+                return DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_ALARMS)
             }
             else if (name === qsTr("Weather")) {
-                return supportsFeature(Amazfish.FEATURE_WEATHER)
+                return DaemonInterfaceInstance.supportsFeature(Amazfish.FEATURE_WEATHER)
             }
             else {
                 return true

--- a/ui/src/daemoninterface.cpp
+++ b/ui/src/daemoninterface.cpp
@@ -139,6 +139,16 @@ bool DaemonInterface::supportsFeature(Amazfish::Feature f)
     return reply;
 }
 
+bool DaemonInterface::supportsDataType(Amazfish::DataType t)
+{
+    if (!iface || !iface->isValid()) {
+        return false;
+    }
+    QDBusReply<bool> reply = iface->call(QStringLiteral("supportsDataType"), (int)t);
+    return reply;
+}
+
+
 int DaemonInterface::supportedFeatures()
 {
     if (!iface || !iface->isValid()) {

--- a/ui/src/daemoninterface.h
+++ b/ui/src/daemoninterface.h
@@ -33,6 +33,7 @@ public:
     Q_INVOKABLE void disconnect();
     Q_INVOKABLE void unpair();
     Q_INVOKABLE bool supportsFeature(Amazfish::Feature f);
+    Q_INVOKABLE bool supportsDataType(Amazfish::DataType t);
     Q_INVOKABLE int supportedFeatures();
     Q_INVOKABLE int supportedDataTypes();
 


### PR DESCRIPTION
same as supportsFeature(), hide unsupported datagraphs.
Additionally, I have noticed redundant functions in harbour-amazfish.qml. Not sure if I should reduce number of functions in this case. 