### PR TITLE
Move service parsing into the abstract device

### DIFF
--- a/daemon/src/devices/abstractdevice.cpp
+++ b/daemon/src/devices/abstractdevice.cpp
@@ -100,8 +100,8 @@ void AbstractDevice::parseServices()
             QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
             QString uuid = devInterface.property("UUID").toString();
 
-            qDebug() << "Creating service for: " << uuid;
             QBLEService *service = drv_createService(uuid, path);
+            qDebug() << "Creating service for: " << uuid << (service != nullptr);
 
             if (service) {
                 addService(uuid, service);

--- a/daemon/src/devices/abstractdevice.cpp
+++ b/daemon/src/devices/abstractdevice.cpp
@@ -3,7 +3,8 @@
 #include "hrmservice.h"
 
 #include <QString>
-    
+#include <QDomDocument>
+
 AbstractDevice::AbstractDevice(const QString &pairedName, QObject *parent) : QBLEDevice(parent)
 {
     qDebug() << Q_FUNC_INFO;
@@ -69,6 +70,45 @@ void AbstractDevice::devicePairFinished(const QString &status)
     qDebug() << Q_FUNC_INFO;
     if (status == "paired") {
         setConnectionState("paired");
+    }
+}
+
+void AbstractDevice::parseServices()
+{
+    qDebug() << Q_FUNC_INFO;
+
+    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
+    QDBusReply<QString> xml = adapterIntro.call("Introspect");
+
+    // qDebug() << "Resolved services...";
+
+    QDomDocument doc;
+    doc.setContent(xml.value());
+
+    QDomNodeList nodes = doc.elementsByTagName("node");
+
+    qDebug() << nodes.count() << "nodes";
+
+    for (int x = 0; x < nodes.count(); x++)
+    {
+        QDomElement node = nodes.at(x).toElement();
+        QString nodeName = node.attribute("name");
+
+        if (nodeName.startsWith("service")) {
+            QString path = devicePath() + "/" + nodeName;
+
+            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
+            QString uuid = devInterface.property("UUID").toString();
+
+            qDebug() << "Creating service for: " << uuid;
+            QBLEService *service = drv_createService(uuid, path);
+
+            if (service) {
+                addService(uuid, service);
+            } else {
+                addService(uuid, new QBLEService(uuid, path, this));
+            }
+        }
     }
 }
 

--- a/daemon/src/devices/abstractdevice.h
+++ b/daemon/src/devices/abstractdevice.h
@@ -116,10 +116,14 @@ protected:
 
     Q_SLOT void deviceError(const QString &message);
 
+    void parseServices();
+    virtual QBLEService* drv_createService(const QString &uuid, const QString &path) = 0;
+
 private:
     void reconnectionTimer();
     void devicePairFinished(const QString& status);
     QString m_pairedName;
+
 
 };
 

--- a/daemon/src/devices/asteroidosdevice.cpp
+++ b/daemon/src/devices/asteroidosdevice.cpp
@@ -103,56 +103,23 @@ void AsteroidOSDevice::onPropertiesChanged(QString interface, QVariantMap map, Q
 
 }
 
-
-void AsteroidOSDevice::parseServices()
+QBLEService *AsteroidOSDevice::drv_createService(const QString &uuid, const QString &path)
 {
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
-                addService(BatteryService::UUID_SERVICE_BATTERY, new BatteryService(path, this));
-            } else if (uuid == AsteroidTimeService::UUID_SERVICE_ASTEROID_TIME && !service(AsteroidTimeService::UUID_SERVICE_ASTEROID_TIME)) {
-                addService(AsteroidTimeService::UUID_SERVICE_ASTEROID_TIME, new AsteroidTimeService(path, this));
-            } else if (uuid == AsteroidWeatherService::UUID_SERVICE_WEATHER && !service(AsteroidWeatherService::UUID_SERVICE_WEATHER)) {
-                addService(AsteroidWeatherService::UUID_SERVICE_WEATHER, new AsteroidWeatherService(path, this));
-            } else if (uuid == AsteroidNotificationService::UUID_SERVICE_NOTIFICATION && !service(AsteroidNotificationService::UUID_SERVICE_NOTIFICATION)) {
-                addService(AsteroidNotificationService::UUID_SERVICE_NOTIFICATION, new AsteroidNotificationService(path, this));
-            } else if (uuid == AsteroidMediaService::UUID_SERVICE_MEDIA  && !service(AsteroidMediaService::UUID_SERVICE_MEDIA  )) {
-                addService(AsteroidMediaService::UUID_SERVICE_MEDIA  , new AsteroidMediaService(path, this));
-            } else if (uuid == AsteroidScreenshotService::UUID_SERVICE_SCREENSHOT  && !service(AsteroidScreenshotService::UUID_SERVICE_SCREENSHOT  )) {
-                addService(AsteroidScreenshotService::UUID_SERVICE_SCREENSHOT, new AsteroidScreenshotService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
+    if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
+        return new BatteryService(path, this);
+    } else if (uuid == AsteroidTimeService::UUID_SERVICE_ASTEROID_TIME && !service(AsteroidTimeService::UUID_SERVICE_ASTEROID_TIME)) {
+        return new AsteroidTimeService(path, this);
+    } else if (uuid == AsteroidWeatherService::UUID_SERVICE_WEATHER && !service(AsteroidWeatherService::UUID_SERVICE_WEATHER)) {
+        return new AsteroidWeatherService(path, this);
+    } else if (uuid == AsteroidNotificationService::UUID_SERVICE_NOTIFICATION && !service(AsteroidNotificationService::UUID_SERVICE_NOTIFICATION)) {
+        return new AsteroidNotificationService(path, this);
+    } else if (uuid == AsteroidMediaService::UUID_SERVICE_MEDIA  && !service(AsteroidMediaService::UUID_SERVICE_MEDIA  )) {
+        return new AsteroidMediaService(path, this);
+    } else if (uuid == AsteroidScreenshotService::UUID_SERVICE_SCREENSHOT  && !service(AsteroidScreenshotService::UUID_SERVICE_SCREENSHOT  )) {
+        return new AsteroidScreenshotService(path, this);
     }
-    setConnectionState("authenticated");
+
+    return nullptr;
 }
 
 void AsteroidOSDevice::initialise()
@@ -191,6 +158,7 @@ void AsteroidOSDevice::initialise()
         connect(screenshot, &AsteroidScreenshotService::screenshotReceived, this, &AsteroidOSDevice::screenshotReceived, Qt::UniqueConnection);
     }
 
+    setConnectionState("authenticated");
 }
 
 

--- a/daemon/src/devices/asteroidosdevice.h
+++ b/daemon/src/devices/asteroidosdevice.h
@@ -22,9 +22,9 @@ public:
 
 protected:
     void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
 private:
-    void parseServices();
     void initialise();
 
     virtual void pair() override;

--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -165,49 +165,17 @@ void BangleJSDevice::incomingCallEnded()
     uart->txJson(o);
 }
 
-
-void BangleJSDevice::parseServices()
+QBLEService *BangleJSDevice::drv_createService(const QString &uuid, const QString &path)
 {
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == UARTService::UUID_SERVICE_UART && !service(UARTService::UUID_SERVICE_UART)) {
-                addService(UARTService::UUID_SERVICE_UART, new UARTService(path, this));
-            } else if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
-                addService(BatteryService::UUID_SERVICE_BATTERY, new BatteryService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
+    if (uuid == UARTService::UUID_SERVICE_UART && !service(UARTService::UUID_SERVICE_UART)) {
+        return new UARTService(path, this);
+    } else if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
+        return new BatteryService(path, this);
+    } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
+        return new DeviceInfoService(path, this);
     }
+
+    return nullptr;
 }
 
 void BangleJSDevice::initialise()

--- a/daemon/src/devices/banglejsdevice.h
+++ b/daemon/src/devices/banglejsdevice.h
@@ -98,9 +98,9 @@ public:
 
 protected:
     virtual void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
 private:
-    void parseServices();
     void initialise();
     Q_SLOT void serviceEvent(uint8_t event);
     Q_SLOT void handleRxJson(const QJsonObject &json);

--- a/daemon/src/devices/dk08device.cpp
+++ b/daemon/src/devices/dk08device.cpp
@@ -115,47 +115,15 @@ void DK08Device::onPropertiesChanged(QString interface, QVariantMap map, QString
 
 }
 
-void DK08Device::parseServices()
+QBLEService *DK08Device::drv_createService(const QString &uuid, const QString &path)
 {
-
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    // qDebug() << "Resolved services...";
-    // qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    // qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == DK08NUSService::UUID_SERVICE_NUS  && !service(DK08NUSService::UUID_SERVICE_NUS)) {
-                addService(DK08NUSService::UUID_SERVICE_NUS, new DK08NUSService(path, this));
-            } else if (uuid == DK08WechatService::UUID_SERVICE_WECHAT  && !service(DK08WechatService::UUID_SERVICE_WECHAT)) {
-                addService(DK08WechatService::UUID_SERVICE_WECHAT, new DK08WechatService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
+    if (uuid == DK08NUSService::UUID_SERVICE_NUS  && !service(DK08NUSService::UUID_SERVICE_NUS)) {
+        return new DK08NUSService(path, this);
+    } else if (uuid == DK08WechatService::UUID_SERVICE_WECHAT  && !service(DK08WechatService::UUID_SERVICE_WECHAT)) {
+        return new DK08WechatService(path, this);
     }
-    setConnectionState("authenticated");
+
+    return nullptr;
 }
 
 void DK08Device::initialise()
@@ -178,6 +146,7 @@ void DK08Device::initialise()
         // nus->test();
     }
 
+    setConnectionState("authenticated");
 }
 
 void DK08Device::refreshInformation()

--- a/daemon/src/devices/dk08device.h
+++ b/daemon/src/devices/dk08device.h
@@ -27,9 +27,9 @@ public:
 
 protected:
     void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
 private:
-    void parseServices();
     void initialise();
     void pair() override;
 

--- a/daemon/src/devices/huami/bipdevice.cpp
+++ b/daemon/src/devices/huami/bipdevice.cpp
@@ -33,56 +33,6 @@ QString BipDevice::deviceType() const
 {
     return "amazfitbip";
 }
-    
-void BipDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x08, 0x00, false, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
-    }
-}
 
 void BipDevice::sendWeather(CurrentWeather *weather)
 {

--- a/daemon/src/devices/huami/bipdevice.h
+++ b/daemon/src/devices/huami/bipdevice.h
@@ -96,9 +96,6 @@ public:
 protected:
     void initialise() override;
 
-private:
-    void parseServices();
-
 };
 
 #endif // BIPDEVICE_H

--- a/daemon/src/devices/huami/biplitedevice.cpp
+++ b/daemon/src/devices/huami/biplitedevice.cpp
@@ -1,6 +1,5 @@
 #include "biplitedevice.h"
 #include "biplitefirmwareinfo.h"
-#include <QtXml/QtXml>
 
 BipLiteDevice::BipLiteDevice(const QString &pairedName, QObject *parent) : BipDevice(pairedName, parent)
 {
@@ -57,57 +56,6 @@ void BipLiteDevice::initialise()
     HRMService *hrm = qobject_cast<HRMService*>(service(HRMService::UUID_SERVICE_HRM));
     if (hrm) {
         connect(hrm, &HRMService::informationChanged, this, &BipDevice::informationChanged, Qt::UniqueConnection);
-    }
-}
-
-
-void BipLiteDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x00, 0x80, true, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
     }
 }
 

--- a/daemon/src/devices/huami/biplitedevice.h
+++ b/daemon/src/devices/huami/biplitedevice.h
@@ -15,10 +15,6 @@ public:
 
 private:
     void initialise() override;
-    void parseServices();
-
-
-private:
     QString pairedName;
 
 };

--- a/daemon/src/devices/huami/bipsdevice.cpp
+++ b/daemon/src/devices/huami/bipsdevice.cpp
@@ -1,5 +1,4 @@
 #include "bipsdevice.h"
-#include <QtXml/QtXml>
 #include "typeconversion.h"
 
 BipSDevice::BipSDevice(const QString &pairedName, QObject *parent) : BipDevice(pairedName, parent)
@@ -72,55 +71,7 @@ void BipSDevice::initialise()
     }
 }
 
-void BipSDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
 
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x00, 0x80, true, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
-    }
-}
 
 void BipSDevice::applyDeviceSetting(Amazfish::Settings s)
 {

--- a/daemon/src/devices/huami/bipsdevice.h
+++ b/daemon/src/devices/huami/bipsdevice.h
@@ -24,7 +24,6 @@ protected:
 
 private:
     Q_SLOT void serviceEvent(uint8_t event);
-    void parseServices();
 };
 
 #endif // BIPSDEVICE_H

--- a/daemon/src/devices/huami/gtrdevice.cpp
+++ b/daemon/src/devices/huami/gtrdevice.cpp
@@ -1,13 +1,11 @@
 #include "gtrdevice.h"
 #include "gtrfirmwareinfo.h"
-#include <QtXml/QtXml>
 #include <QTimer>
 #include "mibandservice.h"
 #include "miband2service.h"
 #include "deviceinfoservice.h"
 #include "bipfirmwareservice.h"
 #include "hrmservice.h"
-#include "alertnotificationservice.h"
 
 GtrDevice::GtrDevice(const QString &pairedName, QObject *parent) : GtsDevice(pairedName, parent)
 {
@@ -82,54 +80,5 @@ void GtrDevice::initialise()
             (!is47mm(revision) && revision >= "0.1.1.15")) { // for GTR 32mm with a different version scheme
         qDebug() << Q_FUNC_INFO << "GTR with new FW";
         m_ActivitySampleSize = 8;
-    }
-}
-
-void GtrDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), nullptr);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), nullptr);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x00, 0x80, true, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
     }
 }

--- a/daemon/src/devices/huami/gtrdevice.h
+++ b/daemon/src/devices/huami/gtrdevice.h
@@ -14,7 +14,6 @@ public:
 
 protected:
     void initialise() override;
-    void parseServices();
 
 private:
     bool is47mm(const QString &version) const;

--- a/daemon/src/devices/huami/gtsdevice.cpp
+++ b/daemon/src/devices/huami/gtsdevice.cpp
@@ -1,6 +1,5 @@
 #include "gtsdevice.h"
 #include "gtsfirmwareinfo.h"
-#include <QtXml/QtXml>
 #include <QDateTime>
 #include "typeconversion.h"
 #include "huami/updatefirmwareoperationnew.h"
@@ -10,7 +9,6 @@
 #include "deviceinfoservice.h"
 #include "bipfirmwareservice.h"
 #include "hrmservice.h"
-#include "alertnotificationservice.h"
 
 GtsDevice::GtsDevice(const QString &pairedName, QObject *parent) : HuamiDevice(pairedName, parent)
 {
@@ -129,58 +127,6 @@ void GtsDevice::initialise()
         m_ActivitySampleSize = 8;
     }
 }
-
-
-void GtsDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), nullptr);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), nullptr);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x00, 0x80, true, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
-    }
-}
-
 
 
 AbstractFirmwareInfo *GtsDevice::firmwareInfo(const QByteArray &bytes, const QString &path)

--- a/daemon/src/devices/huami/gtsdevice.h
+++ b/daemon/src/devices/huami/gtsdevice.h
@@ -32,7 +32,6 @@ public:
 protected:
     Q_SLOT void serviceEvent(uint8_t event);
     void initialise() override;
-    void parseServices();
 
 private:
     QString pairedName;

--- a/daemon/src/devices/huami/huamidevice.cpp
+++ b/daemon/src/devices/huami/huamidevice.cpp
@@ -10,11 +10,10 @@
 
 #include "deviceinfoservice.h"
 #include "mibandservice.h"
+#include "miband2service.h"
 #include "alertnotificationservice.h"
 #include "hrmservice.h"
 #include "bipfirmwareservice.h"
-
-#include <QtXml/QtXml>
 
 HuamiDevice::HuamiDevice(const QString &pairedName, QObject *parent) : AbstractDevice(pairedName, parent)
 {
@@ -514,4 +513,24 @@ void HuamiDevice::characteristicChanged(const QString &characteristic, const QBy
     } else if (characteristic == MiBandService::UUID_CHARACTERISTIC_MIBAND_ACTIVITY_DATA) {
         m_fetcher->fetchData(value);
     }
+}
+
+
+QBLEService *HuamiDevice::drv_createService(const QString &uuid, const QString &path)
+{
+    if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
+        return new AlertNotificationService(path, this);
+    } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
+        return new DeviceInfoService(path, this);
+    } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
+        return new HRMService(path, this);
+    } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
+        return new MiBandService(path, this);
+    } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
+        return new MiBand2Service(path, 0x00, 0x80, true, this);
+    } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
+        return new BipFirmwareService(path, this);
+    }
+
+    return nullptr;
 }

--- a/daemon/src/devices/huami/huamidevice.h
+++ b/daemon/src/devices/huami/huamidevice.h
@@ -65,6 +65,7 @@ protected:
 
     virtual void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
     virtual void initialise() = 0;
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
     int m_ActivitySampleSize = 4;
     HuamiFetcher *m_fetcher = nullptr;

--- a/daemon/src/devices/huami/neodevice.cpp
+++ b/daemon/src/devices/huami/neodevice.cpp
@@ -7,7 +7,6 @@
 #include "hrmservice.h"
 #include "alertnotificationservice.h"
 
-#include <QtXml/QtXml>
 #include <QDateTime>
 
 NeoDevice::NeoDevice(const QString &pairedName, QObject *parent) : HuamiDevice(pairedName, parent)
@@ -94,59 +93,6 @@ void NeoDevice::initialise()
     m_ActivitySampleSize = 8;
 
 }
-
-
-void NeoDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), nullptr);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    // qDebug() << "Resolved services...";
-
-    // qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    // qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), nullptr);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x00, 0x80, true, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
-    }
-}
-
-
 
 AbstractFirmwareInfo *NeoDevice::firmwareInfo(const QByteArray &bytes, const QString &path)
 {

--- a/daemon/src/devices/huami/neodevice.h
+++ b/daemon/src/devices/huami/neodevice.h
@@ -24,7 +24,6 @@ public:
 protected:
     Q_SLOT void serviceEvent(uint8_t event);
     void initialise() override;
-    void parseServices();
 
 private:
     QString pairedName;

--- a/daemon/src/devices/huami/zepposdevice.cpp
+++ b/daemon/src/devices/huami/zepposdevice.cpp
@@ -19,9 +19,7 @@
 #include "deviceinfoservice.h"
 #include "bipfirmwareservice.h"
 #include "hrmservice.h"
-#include "alertnotificationservice.h"
 
-#include <QtXml/QtXml>
 #include <QDebug>
 
 ZeppOSDevice::ZeppOSDevice(const QString &pairedName, QObject *parent) : HuamiDevice(pairedName, parent)
@@ -297,55 +295,12 @@ void ZeppOSDevice::onPropertiesChanged(QString interface, QVariantMap map, QStri
     }
 }
 
-void ZeppOSDevice::parseServices()
+QBLEService *ZeppOSDevice::drv_createService(const QString &uuid, const QString &path)
 {
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), nullptr);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    qDebug() << "Resolved services...";
-
-    qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), nullptr);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this, true));
-            } else if (uuid == MiBandService::UUID_SERVICE_MIBAND && !service(MiBandService::UUID_SERVICE_MIBAND)) {
-                addService(MiBandService::UUID_SERVICE_MIBAND, new MiBandService(path, this));
-            } else if (uuid == MiBand2Service::UUID_SERVICE_MIBAND2 && !service(MiBand2Service::UUID_SERVICE_MIBAND2)) {
-                addService(MiBand2Service::UUID_SERVICE_MIBAND2, new MiBand2Service(path, 0x00, 0x80, true, this));
-            } else if (uuid == BipFirmwareService::UUID_SERVICE_FIRMWARE && !service(BipFirmwareService::UUID_SERVICE_FIRMWARE)) {
-                addService(BipFirmwareService::UUID_SERVICE_FIRMWARE, new BipFirmwareService(path, this));
-            } else if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
-                addService(BatteryService::UUID_SERVICE_BATTERY, new BatteryService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
+    if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
+        return new BatteryService(path, this);
+    } else {
+        return HuamiDevice::drv_createService(uuid, path);
     }
 }
 

--- a/daemon/src/devices/huami/zepposdevice.h
+++ b/daemon/src/devices/huami/zepposdevice.h
@@ -62,10 +62,10 @@ public:
 protected:
     void onPropertiesChanged(QString interface, QVariantMap map, QStringList list) override;
     void initialise() override;
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
 private:
     QDateTime init_dt = QDateTime::fromTime_t(0);
-    void parseServices();
 
     Huami2021ChunkedEncoder *m_encoder = nullptr;
     Huami2021ChunkedDecoder *m_decoder = nullptr;

--- a/daemon/src/devices/pebbledevice.cpp
+++ b/daemon/src/devices/pebbledevice.cpp
@@ -84,47 +84,15 @@ void PebbleDevice::onPropertiesChanged(QString interface, QVariantMap map, QStri
 
 }
 
-void PebbleDevice::parseServices()
+QBLEService *PebbleDevice::drv_createService(const QString &uuid, const QString &path)
 {
-
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    // qDebug() << "Resolved services...";
-    // qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    // qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == PebbleService::UUID_SERVICE_PEBBLE && !service(PebbleService::UUID_SERVICE_PEBBLE)) {
-                addService(PebbleService::UUID_SERVICE_PEBBLE, new PebbleService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
+    if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
+        return new DeviceInfoService(path, this);
+    } else if (uuid == PebbleService::UUID_SERVICE_PEBBLE && !service(PebbleService::UUID_SERVICE_PEBBLE)) {
+        return new PebbleService(path, this);
     }
-    setConnectionState("authenticated");
+
+    return nullptr;
 }
 
 void PebbleDevice::initialise()
@@ -137,6 +105,8 @@ void PebbleDevice::initialise()
     if (info) {
         connect(info, &DeviceInfoService::informationChanged, this, &PebbleDevice::informationChanged, Qt::UniqueConnection);
     }
+
+    setConnectionState("authenticated");
 }
 
 void PebbleDevice::refreshInformation()

--- a/daemon/src/devices/pebbledevice.h
+++ b/daemon/src/devices/pebbledevice.h
@@ -24,9 +24,9 @@ public:
 
 protected:
     void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
 private:
-    void parseServices();
     void initialise();
     virtual void pair() override;
 

--- a/daemon/src/devices/pinetimejfdevice.cpp
+++ b/daemon/src/devices/pinetimejfdevice.cpp
@@ -120,73 +120,6 @@ void PinetimeJFDevice::incomingCallEnded()
     qDebug() << Q_FUNC_INFO << "not available";
 }
 
-
-void PinetimeJFDevice::parseServices()
-{
-    qDebug() << Q_FUNC_INFO;
-
-    QDBusInterface adapterIntro("org.bluez", devicePath(), "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
-    QDBusReply<QString> xml = adapterIntro.call("Introspect");
-
-    // qDebug() << "Resolved services...";
-
-    // qDebug().noquote() << xml.value();
-
-    QDomDocument doc;
-    doc.setContent(xml.value());
-
-    QDomNodeList nodes = doc.elementsByTagName("node");
-
-    qDebug() << nodes.count() << "nodes";
-
-    for (int x = 0; x < nodes.count(); x++)
-    {
-        QDomElement node = nodes.at(x).toElement();
-        QString nodeName = node.attribute("name");
-
-        if (nodeName.startsWith("service")) {
-            QString path = devicePath() + "/" + nodeName;
-
-            QDBusInterface devInterface("org.bluez", path, "org.bluez.GattService1", QDBusConnection::systemBus(), 0);
-            QString uuid = devInterface.property("UUID").toString();
-
-            qDebug() << "Creating service for: " << uuid;
-
-            if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
-                addService(DeviceInfoService::UUID_SERVICE_DEVICEINFO, new DeviceInfoService(path, this));
-            } else if (uuid == CurrentTimeService::UUID_SERVICE_CURRENT_TIME  && !service(CurrentTimeService::UUID_SERVICE_CURRENT_TIME)) {
-                addService(CurrentTimeService::UUID_SERVICE_CURRENT_TIME, new CurrentTimeService(path, this));
-            } else if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION  && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
-                addService(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION, new AlertNotificationService(path, this));
-            } else if (uuid == PineTimeMusicService::UUID_SERVICE_MUSIC  && !service(PineTimeMusicService::UUID_SERVICE_MUSIC  )) {
-                addService(PineTimeMusicService::UUID_SERVICE_MUSIC  , new PineTimeMusicService(path, this));
-            } else if (uuid == DfuService::UUID_SERVICE_DFU && !service(DfuService::UUID_SERVICE_DFU)) {
-                addService(DfuService::UUID_SERVICE_DFU, new DfuService(path, this));
-            } else if (uuid == InfiniTimeNavService::UUID_SERVICE_NAVIGATION && !service(InfiniTimeNavService::UUID_SERVICE_NAVIGATION)) {
-                addService(InfiniTimeNavService::UUID_SERVICE_NAVIGATION, new InfiniTimeNavService(path, this));
-            } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
-                addService(HRMService::UUID_SERVICE_HRM, new HRMService(path, this));
-            } else if (uuid == InfiniTimeMotionService::UUID_SERVICE_MOTION && !service(InfiniTimeMotionService::UUID_SERVICE_MOTION)) {
-                addService(InfiniTimeMotionService::UUID_SERVICE_MOTION, new InfiniTimeMotionService(path, this));
-            } else if (uuid == PineTimeSimpleWeatherService::UUID_SERVICE_SIMPLE_WEATHER && !service(PineTimeSimpleWeatherService::UUID_SERVICE_SIMPLE_WEATHER)) {
-                addService(PineTimeSimpleWeatherService::UUID_SERVICE_SIMPLE_WEATHER, new PineTimeSimpleWeatherService(path, this));
-            } else if (uuid == InfiniTimeWeatherService::UUID_SERVICE_WEATHER && !service(InfiniTimeWeatherService::UUID_SERVICE_WEATHER)) {
-                addService(InfiniTimeWeatherService::UUID_SERVICE_WEATHER, new InfiniTimeWeatherService(path, this));
-            } else if (uuid == AdafruitBleFsService::UUID_SERVICE_FS && !service(AdafruitBleFsService::UUID_SERVICE_FS)) {
-                size_t transferMtu = GetMtuForCharacteristic(path, AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER);
-                addService(AdafruitBleFsService::UUID_SERVICE_FS, new AdafruitBleFsService(path, this, transferMtu));
-            } else if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
-                addService(BatteryService::UUID_SERVICE_BATTERY, new BatteryService(path, this));
-            } else if (uuid == ImmediateAlertService::UUID_SERVICE_IMMEDIATE_ALERT && !service(ImmediateAlertService::UUID_SERVICE_IMMEDIATE_ALERT)) {
-                addService(ImmediateAlertService::UUID_SERVICE_IMMEDIATE_ALERT, new ImmediateAlertService(path, this));
-            } else if ( !service(uuid)) {
-                addService(uuid, new QBLEService(uuid, path, this));
-            }
-        }
-    }
-    setConnectionState("authenticated");
-}
-
 void PinetimeJFDevice::initialise()
 {
     setConnectionState("connected");
@@ -243,6 +176,8 @@ void PinetimeJFDevice::initialise()
     }
 
     connect(&realtimeActivitySample, &RealtimeActivitySample::samplesReady, this, &PinetimeJFDevice::sampledActivity, Qt::UniqueConnection);
+
+    setConnectionState("authenticated");
 }
 
 void PinetimeJFDevice::sampledActivity(QDateTime dt, int kind, int intensity, int steps, int heartrate) {
@@ -314,6 +249,40 @@ void PinetimeJFDevice::onPropertiesChanged(QString interface, QVariantMap map, Q
         }
     }
 
+}
+
+QBLEService *PinetimeJFDevice::drv_createService(const QString &uuid, const QString &path)
+{
+    if (uuid == DeviceInfoService::UUID_SERVICE_DEVICEINFO  && !service(DeviceInfoService::UUID_SERVICE_DEVICEINFO)) {
+        return new DeviceInfoService(path, this);
+    } else if (uuid == CurrentTimeService::UUID_SERVICE_CURRENT_TIME  && !service(CurrentTimeService::UUID_SERVICE_CURRENT_TIME)) {
+        return new CurrentTimeService(path, this);
+    } else if (uuid == AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION  && !service(AlertNotificationService::UUID_SERVICE_ALERT_NOTIFICATION)) {
+        return new AlertNotificationService(path, this);
+    } else if (uuid == PineTimeMusicService::UUID_SERVICE_MUSIC  && !service(PineTimeMusicService::UUID_SERVICE_MUSIC  )) {
+        return new PineTimeMusicService(path, this);
+    } else if (uuid == DfuService::UUID_SERVICE_DFU && !service(DfuService::UUID_SERVICE_DFU)) {
+        return new DfuService(path, this);
+    } else if (uuid == InfiniTimeNavService::UUID_SERVICE_NAVIGATION && !service(InfiniTimeNavService::UUID_SERVICE_NAVIGATION)) {
+        return new InfiniTimeNavService(path, this);
+    } else if (uuid == HRMService::UUID_SERVICE_HRM && !service(HRMService::UUID_SERVICE_HRM)) {
+        return new HRMService(path, this);
+    } else if (uuid == InfiniTimeMotionService::UUID_SERVICE_MOTION && !service(InfiniTimeMotionService::UUID_SERVICE_MOTION)) {
+        return new InfiniTimeMotionService(path, this);
+    } else if (uuid == PineTimeSimpleWeatherService::UUID_SERVICE_SIMPLE_WEATHER && !service(PineTimeSimpleWeatherService::UUID_SERVICE_SIMPLE_WEATHER)) {
+        return new PineTimeSimpleWeatherService(path, this);
+    } else if (uuid == InfiniTimeWeatherService::UUID_SERVICE_WEATHER && !service(InfiniTimeWeatherService::UUID_SERVICE_WEATHER)) {
+        return new InfiniTimeWeatherService(path, this);
+    } else if (uuid == AdafruitBleFsService::UUID_SERVICE_FS && !service(AdafruitBleFsService::UUID_SERVICE_FS)) {
+        size_t transferMtu = GetMtuForCharacteristic(path, AdafruitBleFsService::UUID_CHARACTERISTIC_FS_TRANSFER);
+        return new AdafruitBleFsService(path, this, transferMtu);
+    } else if (uuid == BatteryService::UUID_SERVICE_BATTERY && !service(BatteryService::UUID_SERVICE_BATTERY)) {
+        return  new BatteryService(path, this);
+    } else if (uuid == ImmediateAlertService::UUID_SERVICE_IMMEDIATE_ALERT && !service(ImmediateAlertService::UUID_SERVICE_IMMEDIATE_ALERT)) {
+        return new ImmediateAlertService(path, this);
+    }
+
+    return nullptr;
 }
 
 void PinetimeJFDevice::authenticated(bool ready)

--- a/daemon/src/devices/pinetimejfdevice.h
+++ b/daemon/src/devices/pinetimejfdevice.h
@@ -43,9 +43,9 @@ public:
 
 protected:
     void onPropertiesChanged(QString interface, QVariantMap map, QStringList list);
+    QBLEService* drv_createService(const QString &uuid, const QString &path) override;
 
 private:
-    void parseServices();
     void initialise();
     Q_SLOT void serviceEvent(const QString &characteristic, uint8_t event);
     AbstractFirmwareInfo::Type firmwareType;


### PR DESCRIPTION
This removes the need for every device to implement the XML parsing, and removes a lot of duplication.

Devies now just need to implement a drv_createService function that will create a QBLEService if the device supports that UUID.