### PR TITLE
Zeppos HRM and step goal

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES
 ./src/devices/huami/zeppos/zepposactivitydetailparser.cpp
 ./src/devices/huami/zeppos/zeppostimeservice.cpp
 ./src/devices/huami/zeppos/zepposuserinfoservice.cpp
+./src/devices/huami/zeppos/zepposconfigservice.cpp
 ./src/devices/huami/zeppos/picoproto.cpp
 ./src/devices/huami/zeppos/zepposfiletransferservice.cpp
 ./src/devices/huami/zeppos/filetransfer/zepposfiletransferimpl.cpp
@@ -173,6 +174,7 @@ set(HEADERS
 ./src/devices/huami/zeppos/zepposactivitydetailparser.h
 ./src/devices/huami/zeppos/zeppostimeservice.h
 ./src/devices/huami/zeppos/zepposuserinfoservice.h
+./src/devices/huami/zeppos/zepposconfigservice.h
 ./src/devices/huami/zeppos/zepposfiletransferservice.h
 ./src/devices/huami/zeppos/filetransfer/zepposfiletransferimpl.h
 ./src/devices/huami/zeppos/filetransfer/zepposfiletransferv3.h

--- a/daemon/src/devices/huami/zeppos/zepposconfigservice.cpp
+++ b/daemon/src/devices/huami/zeppos/zepposconfigservice.cpp
@@ -1,5 +1,6 @@
 #include "zepposconfigservice.h"
 #include "amazfishconfig.h"
+#include "typeconversion.h"
 
 ZeppOsConfigService::ZeppOsConfigService(ZeppOSDevice *device) : AbstractZeppOsService(device, false)
 {
@@ -102,7 +103,7 @@ void ZeppOsConfigService::handleConfigResponse(const QByteArray &payload)
     }
 }
 
-void ZeppOsConfigService::setAllDayHeartRateInterval(uint8_t minutes)
+void ZeppOsConfigService::setAllDayHeartRateInterval(char minutes)
 {
     QByteArray cmd;
     cmd += char(CMD_SET);
@@ -110,11 +111,14 @@ void ZeppOsConfigService::setAllDayHeartRateInterval(uint8_t minutes)
     cmd += char(GROUP_HEALTH_VERSION);
     cmd += char(0x00); // reserved
     cmd += char(0x01); // arg count
+    // TODO refactor the above in generic setConfig in upcoming settings
+
+    minutes = minutes < 0 ? -1 : minutes; // Any negative value works for testing "smart"
     cmd += char(ARG_HEART_RATE_ALL_DAY_MONITORING);
     cmd += char(TYPE_BYTE);
     cmd += char(minutes);
 
-    qDebug() << Q_FUNC_INFO << "minutes=" << minutes << cmd.toHex();
+    qDebug() << Q_FUNC_INFO << "minutes=" << (uint8_t)minutes << cmd.toHex();
 
     write(cmd);
 }
@@ -158,14 +162,10 @@ void ZeppOsConfigService::setFitnessGoalSteps(uint32_t steps)
 
     if (stepsType == TYPE_SHORT) {
         // v1: 2-byte little-endian uint16
-        cmd += char(steps & 0xff);
-        cmd += char((steps >> 8) & 0xff);
+        cmd += TypeConversion::fromInt16(steps);
     } else {
         // v2+: 4-byte little-endian uint32
-        cmd += char(steps & 0xff);
-        cmd += char((steps >> 8) & 0xff);
-        cmd += char((steps >> 16) & 0xff);
-        cmd += char((steps >> 24) & 0xff);
+        cmd += TypeConversion::fromInt32(steps);
     }
 
     qDebug() << Q_FUNC_INFO << "steps=" << steps << "type=" << QString::number(stepsType, 16) << cmd.toHex();

--- a/daemon/src/devices/huami/zeppos/zepposconfigservice.cpp
+++ b/daemon/src/devices/huami/zeppos/zepposconfigservice.cpp
@@ -1,4 +1,5 @@
 #include "zepposconfigservice.h"
+#include "amazfishconfig.h"
 
 ZeppOsConfigService::ZeppOsConfigService(ZeppOSDevice *device) : AbstractZeppOsService(device, false)
 {
@@ -10,9 +11,95 @@ QString ZeppOsConfigService::name() const
     return "config";
 }
 
+void ZeppOsConfigService::initialize()
+{
+    qDebug() << Q_FUNC_INFO;
+
+    QByteArray data;
+    data += char(CMD_CAPABILITIES_REQUEST);
+    write(data);
+}
+
 void ZeppOsConfigService::handlePayload(const QByteArray &payload)
 {
-    qDebug() << Q_FUNC_INFO << payload.toHex();
+    switch (payload[0]) {
+    case CMD_CAPABILITIES_RESPONSE:
+        handleCapabilitiesResponse(payload);
+        return;
+
+    case CMD_ACK:
+        qDebug() << "Configuration ACK, status =" << uint8_t(payload[1]);
+        return;
+
+    case CMD_RESPONSE:
+        if (payload[1] != 1) {
+            qDebug() << "Configuration response not success:" << uint8_t(payload[1]);
+            return;
+        }
+        handleConfigResponse(payload);
+        return;
+
+    default:
+        qDebug() << "Unexpected configuration payload byte" << QString::number(uint8_t(payload[0]), 16);
+    }
+}
+
+void ZeppOsConfigService::handleCapabilitiesResponse(const QByteArray &payload)
+{
+    int version = payload[1] & 0xff;
+    qDebug() << "Got config service version =" << version;
+    if (version > 3) {
+        qDebug() << "Unsupported config service version" << version;
+        return;
+    }
+
+    int numGroups = payload[2] & 0xff;
+    if (payload.length() != numGroups + 3) {
+        qDebug() << "Unexpected config capabilities response length" << payload.length() << "for" << numGroups << "groups";
+        return;
+    }
+
+    for (int i = 0; i < numGroups; i++) {
+        uint8_t configGroup = payload[3 + i];
+        qDebug() << "Got supported config group:" << QString::number(configGroup, 16);
+        requestConfig(configGroup);
+    }
+}
+
+void ZeppOsConfigService::requestConfig(uint8_t group)
+{
+    QByteArray cmd;
+    cmd += char(CMD_REQUEST);
+    cmd += char(0x01); // includeConstraints = true
+    cmd += char(group);
+    cmd += char(0x00); // num args = 0 (request all)
+
+    qDebug() << Q_FUNC_INFO << "group =" << QString::number(group, 16) << cmd.toHex();
+
+    write(cmd);
+}
+
+void ZeppOsConfigService::handleConfigResponse(const QByteArray &payload)
+{
+    // payload[0] = CMD_RESPONSE (already checked)
+    // payload[1] = status (already checked)
+    uint8_t configGroup = payload[2];
+    uint8_t version = payload[3];
+
+    // Store the group version for future use (e.g. HEALTH v1 vs v2 type selection)
+    m_groupVersions[configGroup] = version;
+
+    bool includesConstraints = payload[4] == 0x01;
+    int numConfigs = payload[5] & 0xff;
+
+    qDebug() << "Got" << numConfigs << "configs for group" << QString::number(configGroup, 16)
+             << "version" << QString::number(version, 16) << "includesConstraints" << includesConstraints;
+
+    // After receiving HEALTH configs, send the fitness goal if not yet sent
+    if (configGroup == GROUP_HEALTH && !m_sentFitnessGoal) {
+        m_sentFitnessGoal = true;
+        setFitnessGoalSteps(AmazfishConfig::instance()->profileFitnessGoal());
+    }
 }
 
 void ZeppOsConfigService::setAllDayHeartRateInterval(uint8_t minutes)
@@ -51,6 +138,15 @@ void ZeppOsConfigService::setSleepHeartRateDetection(bool enabled)
 
 void ZeppOsConfigService::setFitnessGoalSteps(uint32_t steps)
 {
+    // Choose type based on HEALTH group version: v1 uses SHORT, v2+ uses INT
+    uint8_t stepsType = TYPE_INT; // default for v2+
+    if (m_groupVersions.contains(GROUP_HEALTH)) {
+        uint8_t healthVersion = m_groupVersions[GROUP_HEALTH];
+        if (healthVersion == 0x01) {
+            stepsType = TYPE_SHORT;
+        }
+    }
+
     QByteArray cmd;
     cmd += char(CMD_SET);
     cmd += char(GROUP_HEALTH);
@@ -58,13 +154,21 @@ void ZeppOsConfigService::setFitnessGoalSteps(uint32_t steps)
     cmd += char(0x00); // reserved
     cmd += char(0x01); // arg count
     cmd += char(ARG_FITNESS_GOAL_STEPS);
-    cmd += char(TYPE_INT);
-    cmd += char(steps & 0xff);
-    cmd += char((steps >> 8) & 0xff);
-    cmd += char((steps >> 16) & 0xff);
-    cmd += char((steps >> 24) & 0xff);
+    cmd += char(stepsType);
 
-    qDebug() << Q_FUNC_INFO << "steps=" << steps << cmd.toHex();
+    if (stepsType == TYPE_SHORT) {
+        // v1: 2-byte little-endian uint16
+        cmd += char(steps & 0xff);
+        cmd += char((steps >> 8) & 0xff);
+    } else {
+        // v2+: 4-byte little-endian uint32
+        cmd += char(steps & 0xff);
+        cmd += char((steps >> 8) & 0xff);
+        cmd += char((steps >> 16) & 0xff);
+        cmd += char((steps >> 24) & 0xff);
+    }
+
+    qDebug() << Q_FUNC_INFO << "steps=" << steps << "type=" << QString::number(stepsType, 16) << cmd.toHex();
 
     write(cmd);
 }

--- a/daemon/src/devices/huami/zeppos/zepposconfigservice.cpp
+++ b/daemon/src/devices/huami/zeppos/zepposconfigservice.cpp
@@ -1,0 +1,70 @@
+#include "zepposconfigservice.h"
+
+ZeppOsConfigService::ZeppOsConfigService(ZeppOSDevice *device) : AbstractZeppOsService(device, false)
+{
+    m_endpoint = 0x000a;
+}
+
+QString ZeppOsConfigService::name() const
+{
+    return "config";
+}
+
+void ZeppOsConfigService::handlePayload(const QByteArray &payload)
+{
+    qDebug() << Q_FUNC_INFO << payload.toHex();
+}
+
+void ZeppOsConfigService::setAllDayHeartRateInterval(uint8_t minutes)
+{
+    QByteArray cmd;
+    cmd += char(CMD_SET);
+    cmd += char(GROUP_HEALTH);
+    cmd += char(GROUP_HEALTH_VERSION);
+    cmd += char(0x00); // reserved
+    cmd += char(0x01); // arg count
+    cmd += char(ARG_HEART_RATE_ALL_DAY_MONITORING);
+    cmd += char(TYPE_BYTE);
+    cmd += char(minutes);
+
+    qDebug() << Q_FUNC_INFO << "minutes=" << minutes << cmd.toHex();
+
+    write(cmd);
+}
+
+void ZeppOsConfigService::setSleepHeartRateDetection(bool enabled)
+{
+    QByteArray cmd;
+    cmd += char(CMD_SET);
+    cmd += char(GROUP_HEALTH);
+    cmd += char(GROUP_HEALTH_VERSION);
+    cmd += char(0x00); // reserved
+    cmd += char(0x01); // arg count
+    cmd += char(ARG_HEART_RATE_SLEEP_SUPPORT);
+    cmd += char(TYPE_BOOL);
+    cmd += (enabled ? char(0x01) : char(0x00));
+
+    qDebug() << Q_FUNC_INFO << "enabled=" << enabled << cmd.toHex();
+
+    write(cmd);
+}
+
+void ZeppOsConfigService::setFitnessGoalSteps(uint32_t steps)
+{
+    QByteArray cmd;
+    cmd += char(CMD_SET);
+    cmd += char(GROUP_HEALTH);
+    cmd += char(GROUP_HEALTH_VERSION);
+    cmd += char(0x00); // reserved
+    cmd += char(0x01); // arg count
+    cmd += char(ARG_FITNESS_GOAL_STEPS);
+    cmd += char(TYPE_INT);
+    cmd += char(steps & 0xff);
+    cmd += char((steps >> 8) & 0xff);
+    cmd += char((steps >> 16) & 0xff);
+    cmd += char((steps >> 24) & 0xff);
+
+    qDebug() << Q_FUNC_INFO << "steps=" << steps << cmd.toHex();
+
+    write(cmd);
+}

--- a/daemon/src/devices/huami/zeppos/zepposconfigservice.h
+++ b/daemon/src/devices/huami/zeppos/zepposconfigservice.h
@@ -8,24 +8,24 @@
 class ZeppOsConfigService : public AbstractZeppOsService
 {
 public:
-    static const uint8_t CMD_CAPABILITIES_REQUEST  = 0x01;
-    static const uint8_t CMD_CAPABILITIES_RESPONSE = 0x02;
-    static const uint8_t CMD_REQUEST               = 0x03;
-    static const uint8_t CMD_RESPONSE              = 0x04;
-    static const uint8_t CMD_SET                   = 0x05;
-    static const uint8_t CMD_ACK                   = 0x06;
+    static constexpr uint8_t CMD_CAPABILITIES_REQUEST  = 0x01;
+    static constexpr uint8_t CMD_CAPABILITIES_RESPONSE = 0x02;
+    static constexpr uint8_t CMD_REQUEST               = 0x03;
+    static constexpr uint8_t CMD_RESPONSE              = 0x04;
+    static constexpr uint8_t CMD_SET                   = 0x05;
+    static constexpr uint8_t CMD_ACK                   = 0x06;
 
-    static const uint8_t GROUP_HEALTH = 0x08;
-    static const uint8_t GROUP_HEALTH_VERSION = 0x02;
+    static constexpr uint8_t GROUP_HEALTH = 0x08;
+    static constexpr uint8_t GROUP_HEALTH_VERSION = 0x02;
 
-    static const uint8_t ARG_HEART_RATE_ALL_DAY_MONITORING = 0x01;
-    static const uint8_t ARG_HEART_RATE_SLEEP_SUPPORT = 0x11;
-    static const uint8_t ARG_FITNESS_GOAL_STEPS = 0x52;
+    static constexpr uint8_t ARG_HEART_RATE_ALL_DAY_MONITORING = 0x01;
+    static constexpr uint8_t ARG_HEART_RATE_SLEEP_SUPPORT = 0x11;
+    static constexpr uint8_t ARG_FITNESS_GOAL_STEPS = 0x52;
 
-    static const uint8_t TYPE_SHORT = 0x01;
-    static const uint8_t TYPE_INT   = 0x03;
-    static const uint8_t TYPE_BOOL  = 0x0b;
-    static const uint8_t TYPE_BYTE  = 0x10;
+    static constexpr uint8_t TYPE_SHORT = 0x01;
+    static constexpr uint8_t TYPE_INT   = 0x03;
+    static constexpr uint8_t TYPE_BOOL  = 0x0b;
+    static constexpr uint8_t TYPE_BYTE  = 0x10;
 
     ZeppOsConfigService(ZeppOSDevice *device);
 
@@ -33,7 +33,7 @@ public:
     void handlePayload(const QByteArray &payload) override;
     void initialize() override;
 
-    void setAllDayHeartRateInterval(uint8_t minutes);
+    void setAllDayHeartRateInterval(char minutes);
     void setSleepHeartRateDetection(bool enabled);
     void setFitnessGoalSteps(uint32_t steps);
 

--- a/daemon/src/devices/huami/zeppos/zepposconfigservice.h
+++ b/daemon/src/devices/huami/zeppos/zepposconfigservice.h
@@ -1,0 +1,32 @@
+#ifndef ZEPPOSCONFIGSERVICE_H
+#define ZEPPOSCONFIGSERVICE_H
+
+#include "abstractzepposservice.h"
+
+class ZeppOsConfigService : public AbstractZeppOsService
+{
+public:
+    static const uint8_t CMD_SET = 0x05;
+
+    static const uint8_t GROUP_HEALTH = 0x08;
+    static const uint8_t GROUP_HEALTH_VERSION = 0x02;
+
+    static const uint8_t ARG_HEART_RATE_ALL_DAY_MONITORING = 0x01;
+    static const uint8_t ARG_HEART_RATE_SLEEP_SUPPORT = 0x11;
+    static const uint8_t ARG_FITNESS_GOAL_STEPS = 0x52;
+
+    static const uint8_t TYPE_BOOL = 0x0b;
+    static const uint8_t TYPE_BYTE = 0x10;
+    static const uint8_t TYPE_INT = 0x03;
+
+    ZeppOsConfigService(ZeppOSDevice *device);
+
+    QString name() const override;
+    void handlePayload(const QByteArray &payload) override;
+
+    void setAllDayHeartRateInterval(uint8_t minutes);
+    void setSleepHeartRateDetection(bool enabled);
+    void setFitnessGoalSteps(uint32_t steps);
+};
+
+#endif // ZEPPOSCONFIGSERVICE_H

--- a/daemon/src/devices/huami/zeppos/zepposconfigservice.h
+++ b/daemon/src/devices/huami/zeppos/zepposconfigservice.h
@@ -3,10 +3,17 @@
 
 #include "abstractzepposservice.h"
 
+#include <QMap>
+
 class ZeppOsConfigService : public AbstractZeppOsService
 {
 public:
-    static const uint8_t CMD_SET = 0x05;
+    static const uint8_t CMD_CAPABILITIES_REQUEST  = 0x01;
+    static const uint8_t CMD_CAPABILITIES_RESPONSE = 0x02;
+    static const uint8_t CMD_REQUEST               = 0x03;
+    static const uint8_t CMD_RESPONSE              = 0x04;
+    static const uint8_t CMD_SET                   = 0x05;
+    static const uint8_t CMD_ACK                   = 0x06;
 
     static const uint8_t GROUP_HEALTH = 0x08;
     static const uint8_t GROUP_HEALTH_VERSION = 0x02;
@@ -15,18 +22,28 @@ public:
     static const uint8_t ARG_HEART_RATE_SLEEP_SUPPORT = 0x11;
     static const uint8_t ARG_FITNESS_GOAL_STEPS = 0x52;
 
-    static const uint8_t TYPE_BOOL = 0x0b;
-    static const uint8_t TYPE_BYTE = 0x10;
-    static const uint8_t TYPE_INT = 0x03;
+    static const uint8_t TYPE_SHORT = 0x01;
+    static const uint8_t TYPE_INT   = 0x03;
+    static const uint8_t TYPE_BOOL  = 0x0b;
+    static const uint8_t TYPE_BYTE  = 0x10;
 
     ZeppOsConfigService(ZeppOSDevice *device);
 
     QString name() const override;
     void handlePayload(const QByteArray &payload) override;
+    void initialize() override;
 
     void setAllDayHeartRateInterval(uint8_t minutes);
     void setSleepHeartRateDetection(bool enabled);
     void setFitnessGoalSteps(uint32_t steps);
+
+private:
+    void handleCapabilitiesResponse(const QByteArray &payload);
+    void handleConfigResponse(const QByteArray &payload);
+    void requestConfig(uint8_t group);
+
+    QMap<uint8_t, uint8_t> m_groupVersions;
+    bool m_sentFitnessGoal = false;
 };
 
 #endif // ZEPPOSCONFIGSERVICE_H

--- a/daemon/src/devices/huami/zepposdevice.cpp
+++ b/daemon/src/devices/huami/zepposdevice.cpp
@@ -13,12 +13,14 @@
 #include "zeppos/zeppostimeservice.h"
 #include "zeppos/zepposuserinfoservice.h"
 #include "zeppos/zepposagpsservice.h"
+#include "zeppos/zepposconfigservice.h"
 #include "zepposfirmwareinfo.h"
 #include "mibandservice.h"
 #include "miband2service.h"
 #include "deviceinfoservice.h"
 #include "bipfirmwareservice.h"
 #include "hrmservice.h"
+#include "amazfishconfig.h"
 
 #include <QDebug>
 
@@ -59,6 +61,9 @@ ZeppOSDevice::ZeppOSDevice(const QString &pairedName, QObject *parent) : HuamiDe
 
     m_fileTransferService = new ZeppOsFileTransferService(this);
     m_zosServiceMap[m_fileTransferService->endpoint()] = m_fileTransferService;
+
+    m_configService = new ZeppOsConfigService(this);
+    m_zosServiceMap[m_configService->endpoint()] = m_configService;
 }
 
 QString ZeppOSDevice::deviceType() const
@@ -131,10 +136,24 @@ void ZeppOSDevice::applyDeviceSetting(Amazfish::Settings s)
             m_userInfoService->setUserInfo();
         }
         break;
-    case Amazfish::Settings::SETTING_USER_GOAL:
-    case Amazfish::Settings::SETTING_USER_ALERT_GOAL:
     case Amazfish::Settings::SETTING_USER_ALL_DAY_HRM:
+        if (m_configService) {
+            auto interval = AmazfishConfig::instance()->profileAllDayHRM();
+            uint8_t intervalClamped = static_cast<uint8_t>(qMin(120u, interval));
+            m_configService->setAllDayHeartRateInterval(intervalClamped);
+        }
+        break;
     case Amazfish::Settings::SETTING_USER_HRM_SLEEP_DETECTION:
+        if (m_configService) {
+            m_configService->setSleepHeartRateDetection(AmazfishConfig::instance()->profileHRMSleepSupport());
+        }
+        break;
+    case Amazfish::Settings::SETTING_USER_GOAL:
+        if (m_configService) {
+            m_configService->setFitnessGoalSteps(AmazfishConfig::instance()->profileFitnessGoal());
+        }
+        break;
+    case Amazfish::Settings::SETTING_USER_ALERT_GOAL:
     case Amazfish::Settings::SETTING_USER_DISPLAY_ON_LIFT:
     case Amazfish::Settings::SETTING_ALARMS:
     case Amazfish::Settings::SETTING_DEVICE_DISPLAY_ITEMS:

--- a/daemon/src/devices/huami/zepposdevice.cpp
+++ b/daemon/src/devices/huami/zepposdevice.cpp
@@ -139,8 +139,7 @@ void ZeppOSDevice::applyDeviceSetting(Amazfish::Settings s)
     case Amazfish::Settings::SETTING_USER_ALL_DAY_HRM:
         if (m_configService) {
             auto interval = AmazfishConfig::instance()->profileAllDayHRM();
-            uint8_t intervalClamped = static_cast<uint8_t>(qMin(120u, interval));
-            m_configService->setAllDayHeartRateInterval(intervalClamped);
+            m_configService->setAllDayHeartRateInterval(interval);
         }
         break;
     case Amazfish::Settings::SETTING_USER_HRM_SLEEP_DETECTION:

--- a/daemon/src/devices/huami/zepposdevice.h
+++ b/daemon/src/devices/huami/zepposdevice.h
@@ -17,6 +17,7 @@ class ZeppOsTimeService;
 class ZeppOsUserInfoService;
 class ZeppOsAgpsService;
 class ZeppOsFileTransferService;
+class ZeppOsConfigService;
 class AbstractZeppOsOperation;
 
 class ZeppOSDevice: public HuamiDevice, public Huami2021Handler, public ZeppOsFileTransferService::Callback
@@ -79,6 +80,7 @@ private:
     ZeppOsUserInfoService *m_userInfoService = nullptr;
     ZeppOsAgpsService *m_agpsService = nullptr;
     ZeppOsFileTransferService *m_fileTransferService = nullptr;
+    ZeppOsConfigService *m_configService = nullptr;
 
 
     QMap<short, AbstractZeppOsService *> m_zosServiceMap;

--- a/lib/src/amazfishconfig.h
+++ b/lib/src/amazfishconfig.h
@@ -170,7 +170,7 @@ public:
 
     UINT_OPTION(QStringLiteral("profile/height"),      profileHeight,      setProfileHeight,      170)
     UINT_OPTION(QStringLiteral("profile/weight"),      profileWeight,      setProfileWeight,      70)
-    UINT_OPTION(QStringLiteral("profile/alldayhrm"),   profileAllDayHRM,   setProfileAllDayHRM,   0)
+    INT_OPTION(QStringLiteral("profile/alldayhrm"),    profileAllDayHRM,   setProfileAllDayHRM,   0)
     UINT_OPTION(QStringLiteral("profile/fitnessgoal"), profileFitnessGoal, setProfileFitnessGoal, 10000)
 
     BOOL_OPTION(QStringLiteral("profile/alertfitnessgoal"),   profileAlertFitnessGoal,   setProfileAlertFitnessGoal,   false)

--- a/ui/qml/pages/Settings-user.qml
+++ b/ui/qml/pages/Settings-user.qml
@@ -200,8 +200,8 @@ PagePL {
 
             minimumValue: 0
             maximumValue: 60
-            stepSize: 1
-            label: qsTr("All day HRM interval (minutes): ") + value
+            stepSize: 5
+            label: qsTr("All day HRM interval (minutes): ") + (value < 0 ? "smart" : String(value))
         }
 
         ButtonPL {


### PR DESCRIPTION
Except the [-1 smart](https://codeberg.org/Freeyourgadget/Gadgetbridge/src/branch/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/huami/zeppos/ZeppOsSupport.java#L370-L372) which I probably don't have and would require UI change.

Should save: HRM sleep detection, HRM interval and Step goal on the device.