### PR TITLE
Add quick weather access to Bip

### DIFF
--- a/daemon/src/services/mibandservice.cpp
+++ b/daemon/src/services/mibandservice.cpp
@@ -411,6 +411,24 @@ void MiBandService::setEnableDisplayOnLiftWrist()
     writeValue(UUID_CHARACTERISTIC_MIBAND_CONFIGURATION, cmd);
 }
 
+void MiBandService::setDisplayShortcuts()
+{
+    auto config = AmazfishConfig::instance();
+    auto sw = config->deviceDisplayWeatherShortcut();
+    auto sa = config->deviceDisplayAliPayShortcut();
+
+    QByteArray shortcuts;
+    shortcuts += 0x10;
+    shortcuts += ((sa || sw) ? 0x80 : 0x00);
+    shortcuts += (sw ? 0x02 : 0x01);
+    shortcuts += ((sa && sw) ? 0x81 : 0x01);
+    shortcuts += 0x01;
+
+    qDebug() << Q_FUNC_INFO << "Setting shortcuts to:" << shortcuts;
+
+    writeValue(UUID_CHARACTERISTIC_MIBAND_CONFIGURATION, shortcuts);
+}
+
 void MiBandService::setDisplayItems()
 {
     uint8_t items1 = 0x01; //Always display clock
@@ -458,20 +476,7 @@ void MiBandService::setDisplayItems()
     writeValue(UUID_CHARACTERISTIC_MIBAND_CONFIGURATION, cmd);
 
     //Shortcuts
-    auto config = AmazfishConfig::instance();
-    auto sw = config->deviceDisplayWeatherShortcut();
-    auto sa = config->deviceDisplayAliPayShortcut();
-
-    QByteArray shortcuts;
-    shortcuts += 0x10;
-    shortcuts += ((sa || sw) ? 0x80 : 0x00);
-    shortcuts += (sw ? 0x02 : 0x01);
-    shortcuts += ((sa && sw) ? 0x81 : 0x01);
-    shortcuts += 0x01;
-
-    qDebug() << Q_FUNC_INFO << "Setting shortcuts to:" << shortcuts;
-
-    writeValue(UUID_CHARACTERISTIC_MIBAND_CONFIGURATION, shortcuts);
+    setDisplayShortcuts();
 }
 
 void MiBandService::setDisplayItemsOld(QMap<QString, uint8_t> keyPosMap)
@@ -515,6 +520,9 @@ void MiBandService::setDisplayItemsOld(QMap<QString, uint8_t> keyPosMap)
     command[2] = (uint8_t) ((enabled_mask >> 8 & 0xff));
 
     writeValue(UUID_CHARACTERISTIC_MIBAND_CONFIGURATION, command);
+
+    //Shortcuts
+    setDisplayShortcuts();
 }
 
 void MiBandService::setDisplayItemsNew()

--- a/daemon/src/services/mibandservice.h
+++ b/daemon/src/services/mibandservice.h
@@ -200,6 +200,7 @@ private:
     QMap<QString, uint8_t> displayItemsIdMap;
 
     Huami2021ChunkedDecoder *m_decoder = nullptr;
+    void setDisplayShortcuts();
 };
 
 #endif // MIBANDSERVICE_H


### PR DESCRIPTION
Adding display item ordering broke quick weather access on old Bip.

I had not noticed before, as the old configuration was still in place.