### PR TITLE
[Bangle.js] Queue for uart transfer for bangle.js

### DIFF
--- a/daemon/src/services/uartservice.cpp
+++ b/daemon/src/services/uartservice.cpp
@@ -8,8 +8,13 @@ UARTService::UARTService(const QString &path, QObject *parent) : QBLEService(UUI
 {
     qDebug() << Q_FUNC_INFO;
     connect(this, &QBLEService::characteristicChanged, this, &UARTService::characteristicChanged);
+
+    m_txTimer.setSingleShot(true);
+    connect(&m_txTimer, &QTimer::timeout, this, &UARTService::sendNextPacket);
 }
 
+// Queue the data in 20 byte packets. One packet is written per event loop
+// iteration, so that incoming XOFF is not missed while a long message is sent.
 void UARTService::tx(const QByteArray &bytes)
 {
     qDebug() << Q_FUNC_INFO << bytes;
@@ -20,8 +25,33 @@ void UARTService::tx(const QByteArray &bytes)
             l = 20;
         }
 
-        QByteArray packet = bytes.mid(i, l);
-        writeValue(UUID_CHARACTERISTIC_UART_TX, packet);
+        m_txQueue.enqueue(bytes.mid(i, l));
+    }
+
+    if (!m_txTimer.isActive()) {
+        m_txTimer.start(0);
+    }
+}
+
+void UARTService::sendNextPacket()
+{
+    if (m_txQueue.isEmpty()) {
+        return;
+    }
+
+    if (m_txPaused) { // wait for XON
+        m_txTimer.start(100);
+        return;
+    }
+
+    if (!writeValue(UUID_CHARACTERISTIC_UART_TX, m_txQueue.dequeue())) {
+        qWarning() << Q_FUNC_INFO << "write failed, dropping" << m_txQueue.count() << "queued packets";
+        m_txQueue.clear();
+        return;
+    }
+
+    if (!m_txQueue.isEmpty()) {
+        m_txTimer.start(0);
     }
 }
 
@@ -40,7 +70,21 @@ void UARTService::characteristicChanged(const QString &c, const QByteArray &valu
     // qDebug() << Q_FUNC_INFO << c << value;
 
     if (c == UUID_CHARACTERISTIC_UART_RX) {
-        m_incomingJson += value;
+        // Espruino throttles us with XOFF/XON when its input buffer fills up
+        QByteArray data;
+        data.reserve(value.length());
+        for (int i = 0; i < value.length(); ++i) {
+            const char ch = value.at(i);
+            if (ch == 0x13) {        // XOFF
+                m_txPaused = true;
+            } else if (ch == 0x11) { // XON
+                m_txPaused = false;
+            } else {
+                data.append(ch);
+            }
+        }
+
+        m_incomingJson += data;
         while (m_incomingJson.contains("\n")) {
             int p = m_incomingJson.indexOf("\n");
             QString json =  m_incomingJson.mid(0,p-1);

--- a/daemon/src/services/uartservice.h
+++ b/daemon/src/services/uartservice.h
@@ -2,6 +2,8 @@
 #define UARTSERVICE_H
 
 #include <QObject>
+#include <QQueue>
+#include <QTimer>
 #include "qble/qbleservice.h"
 #include "abstractdevice.h"
 
@@ -29,8 +31,12 @@ private:
     void characteristicChanged(const QString &c, const QByteArray &value);
     void handleRx(const QString &json);
     QJsonObject ObjectFromString(const QString& in);
+    void sendNextPacket();
 
     QByteArray m_incomingJson;
+    QQueue<QByteArray> m_txQueue;
+    QTimer m_txTimer;
+    bool m_txPaused = false; // device sent XOFF
 };
 
 #endif // UARTSERVICE_H


### PR DESCRIPTION
There is a similar mechanism in Gadgetbridge:
https://github.com/Freeyourgadget/Gadgetbridge/blob/a0948ee1cbc2a870f91d313f8e37df5f524465f7/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/banglejs/BangleJSDeviceSupport.java#L1196

I’m trying to figure out why the Bangle.js freezes, and Claude suggested copying this mechanism.

I still need to run some tests, though.