### PR TITLE
[bangle.js] fetchData(TYPE_GPS_TRACK) calls downloadActivityData() .

### DIFF
--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -328,7 +328,7 @@ void BangleJSDevice::fetchData(Amazfish::DataTypes dataTypes)
     }
 
     if (dataTypes & Amazfish::DataType::TYPE_GPS_TRACK) {
-        downloadActivityData();
+        downloadSportsData();
     }
 }
 


### PR DESCRIPTION
Should be downloadSportsData(), which is currently dead code — so the Download button on SportsSummaryPage.qml:43 has done nothing since 9edca8ea