### PR TITLE
[Bangle.js] prevent double initialization

### DIFF
--- a/daemon/src/devices/banglejsdevice.cpp
+++ b/daemon/src/devices/banglejsdevice.cpp
@@ -278,8 +278,12 @@ void BangleJSDevice::onPropertiesChanged(QString interface, QVariantMap map, QSt
 
     if (interface == "org.bluez.Device1") {
         m_reconnectTimer->start();
-        if (deviceProperty("ServicesResolved").toBool() ) {
+        const bool resolved = deviceProperty("ServicesResolved").toBool();
+        if (resolved && !m_initialised) { // bluez repeats Device1 properties, initialise once per connection
+            m_initialised = true;
             initialise();
+        } else if (!resolved) {
+            m_initialised = false;
         }
         if (map.contains("Connected")) {
             bool value = map["Connected"].toBool();

--- a/daemon/src/devices/banglejsdevice.h
+++ b/daemon/src/devices/banglejsdevice.h
@@ -108,6 +108,7 @@ private:
     void downloadSportsData();
 
     bool m_operationRunning = false;
+    bool m_initialised = false;
     void setOperationRunning(bool running);
     int m_infoBatteryLevel = 0;
     int m_steps = 0;


### PR DESCRIPTION
onPropertiesChanged runs initialise() on any Device1 property change while ServicesResolved is true, and initialise() flips state connected→authenticated, which makes DeviceInterface run updateCalendar() again. Full calendar dump, more than once per connection. Same pattern in pinetimejfdevice.cpp:243, so it's not Bangle-specific — but it got expensive once calendar sync got heavy