### PR TITLE
Set clang format webkit as default format, check format in new commits

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: WebKit

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,25 @@
+name: clang-format Check
+
+on: [push, pull_request]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Ubuntu 24.04 ships a fixed 18.1.3, so the result does not drift.
+      - run: sudo apt-get update -qq && sudo apt-get install -y clang-format-18
+
+      - name: Check formatting of changed lines
+        run: |
+          git diff -U0 origin/master...HEAD -- \
+              '*.c' '*.cpp' '*.h' '*.hpp' ':(exclude)ui/o2' \
+            | clang-format-diff-18 -p1 | tee format.diff
+          if [ -s format.diff ]; then
+            echo "Fix it: git diff -U0 origin/master...HEAD | clang-format-diff-18 -p1 -i"
+            exit 1
+          fi


### PR DESCRIPTION
I have this kind of script in my home. The clang-format for the project should be specified in order to get reasonable formatting fixes.


```
mkdir -p ~/.git-templates/hooks
cat > ~/.git-templates/hooks/pre-commit <<'EOF'
#!/usr/bin/env bash
# Runs clang-format on staged files. Blocks on first failure, allows on second.

FLAG="$(git rev-parse --git-dir)/.clang_format_warned"

files=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(c|cc|cpp|h|hpp)$' || true) #'
[ -z "$files" ] && exit 0

bad=""
while read -r f; do
  diff <(git show ":$f") <(git show ":$f" | clang-format --assume-filename="$f") \
    > /dev/null || bad="$bad$f "
done <<< "$files"

if [ -z "$bad" ]; then
  rm -f "$FLAG"
  exit 0
fi

if [ -f "$FLAG" ]; then
  rm -f "$FLAG"
  echo "[pre-commit] Second attempt -- committing anyway."
  exit 0
else
  echo "[pre-commit] Formatting issues found. Commit again to override."
  echo ""
  echo "check it out"
  echo "  git diff --cached | clang-format-diff -p1"
  echo "fix it"
  echo "  git diff --cached | clang-format-diff -p1 -i && git add -u"
  touch "$FLAG"
  exit 1
fi
EOF

chmod +x ~/.git-templates/hooks/pre-commit
```

I have tried to propose github action which should fail/warn on incorrect format of that proposed patch. I am not sure how to verify something like this without merging.